### PR TITLE
Allow waveform.set() to be called before iocInit()

### DIFF
--- a/softioc/device.py
+++ b/softioc/device.py
@@ -293,6 +293,8 @@ class WaveformBase(ProcessDeviceSupportCore):
     #   NELM    Length of allocated array in number of elements
     #   NORD    Currently reported length of array (0 <= NORD <= NELM)
     _fields_ = ['UDF', 'FTVL', 'BPTR', 'NELM', 'NORD']
+    # Allow set() to be called before init_record:
+    dtype = None
 
     def init_record(self, record):
         self.dtype = DbfCodeToNumpy[record.FTVL]

--- a/tests/sim_records.py
+++ b/tests/sim_records.py
@@ -42,6 +42,8 @@ def update_sin_wf(value):
     sin_wf.set(numpy.sin(
         numpy.linspace(0, 2*numpy.pi*sin_ph.get(), sin_len.get())))
 sin_wf = Waveform('SIN', datatype = float, length = 1024)
+# Check we can update its value before iocInit as per #22
+sin_wf.set([1, 2, 3])
 sin_len = longOut(
     'SINN', 0, 1024, initial_value=1024, on_update=update_sin_wf)
 sin_ph = aOut('SINP', initial_value = 0.0, on_update = update_sin_wf)


### PR DESCRIPTION
Fixes #21.

With CGP-182 (944e072), waveform.set() was modified to use the dtype attribute, which is only created after softioc.iocInit() is called.

This change adds a default for dtype, preventing this issue.