### PR TITLE
Confirm less than 17 labels provided during mbbi/mbbo record creation

### DIFF
--- a/softioc/builder.py
+++ b/softioc/builder.py
@@ -70,6 +70,8 @@ def _process_mbb_values(options, fields):
         fields[prefix + 'VL'] = value
         if severity:
             fields[prefix + 'SV'] = severity
+
+    assert len(options) <= 16, "May not specify more than 16 enum values"
     for prefix, (value, option) in zip(_mbbPrefixes, enumerate(options)):
         if isinstance(option, tuple):
             # The option is tuple consisting of the option name and an optional

--- a/softioc/builder.py
+++ b/softioc/builder.py
@@ -70,7 +70,7 @@ def _process_mbb_values(options, fields):
         fields[prefix + 'VL'] = value
         if severity:
             fields[prefix + 'SV'] = severity
-
+    # zip() silently ignores extra values in options, so explicitly check length
     assert len(options) <= 16, "May not specify more than 16 enum values"
     for prefix, (value, option) in zip(_mbbPrefixes, enumerate(options)):
         if isinstance(option, tuple):

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 from softioc import builder
 
@@ -10,3 +11,10 @@ def test_records(tmp_path):
     builder.WriteRecords(path)
     expected = os.path.join(os.path.dirname(__file__), "expected_records.db")
     assert open(path).readlines()[4:] == open(expected).readlines()[4:]
+
+def test_enum_length_restriction():
+    with pytest.raises(AssertionError):
+        builder.mbbIn(
+                "ManyLabels", "one", "two", "three", "four", "five", "six",
+                "seven", "eight", "nine", "ten", "eleven", "twelve", "thirteen",
+                "fourteen", "fifteen", "sixteen", "seventeen")


### PR DESCRIPTION
Raise an AssertionError when more than the maximum of 16 labels are provided during mbbi/mbbo record creation. 