### PR TITLE
Fixup atexit handling

### DIFF
--- a/softioc/imports.py
+++ b/softioc/imports.py
@@ -97,7 +97,7 @@ iocInit = dbCore.iocInit
 iocInit.argtypes = ()
 
 epicsExit = Com.epicsExit
-epicsExit.argtypes = ()
+epicsExit.argtypes = (c_int,)
 
 
 __all__ = [

--- a/softioc/imports.py
+++ b/softioc/imports.py
@@ -99,6 +99,10 @@ iocInit.argtypes = ()
 epicsExit = Com.epicsExit
 epicsExit.argtypes = (c_int,)
 
+epicsExitCallAtExits = Com.epicsExitCallAtExits
+epicsExitCallAtExits.argtypes = ()
+epicsExitCallAtExits.restype = None
+
 
 __all__ = [
     'get_field_offsets',

--- a/softioc/softioc.py
+++ b/softioc/softioc.py
@@ -36,7 +36,7 @@ def iocInit(dispatcher=None):
     imports.iocInit()
 
 
-def safeEpicsExit():
+def safeEpicsExit(code=0):
     '''Calls epicsExit() after ensuring Python exit handlers called.'''
     if hasattr(sys, 'exitfunc'):
         try:
@@ -46,7 +46,7 @@ def safeEpicsExit():
         finally:
             # Make sure we don't try the exit handlers more than once!
             del sys.exitfunc
-    epicsExit()
+    epicsExit(code)
 
 # The following identifiers will be exported to interactive shell.
 command_names = []

--- a/softioc/softioc.py
+++ b/softioc/softioc.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import atexit
 from ctypes import *
 from tempfile import NamedTemporaryFile
 
@@ -38,7 +39,7 @@ def iocInit(dispatcher=None):
 
 def safeEpicsExit(code=0):
     '''Calls epicsExit() after ensuring Python exit handlers called.'''
-    if hasattr(sys, 'exitfunc'):
+    if hasattr(sys, 'exitfunc'): # py 2.x
         try:
             # Calling epicsExit() will bypass any atexit exit handlers, so call
             # them explicitly now.
@@ -46,6 +47,12 @@ def safeEpicsExit(code=0):
         finally:
             # Make sure we don't try the exit handlers more than once!
             del sys.exitfunc
+
+    elif hasattr(atexit, '_run_exitfuncs'): # py 3.x
+        atexit._run_exitfuncs()
+
+    # calls epicsExitCallAtExits()
+    # and then OS exit()
     epicsExit(code)
 
 # The following identifiers will be exported to interactive shell.

--- a/softioc/softioc.py
+++ b/softioc/softioc.py
@@ -11,7 +11,10 @@ from . import imports, device
 __all__ = ['dbLoadDatabase', 'iocInit', 'interactive_ioc']
 
 
-epicsExit = imports.epicsExit
+# tie in epicsAtExit() to interpreter lifecycle
+@atexit.register
+def epicsAtPyExit():
+    imports.epicsExitCallAtExits()
 
 
 def iocInit(dispatcher=None):
@@ -39,7 +42,7 @@ def iocInit(dispatcher=None):
 
 def safeEpicsExit(code=0):
     '''Calls epicsExit() after ensuring Python exit handlers called.'''
-    if hasattr(sys, 'exitfunc'): # py 2.x
+    if hasattr(sys, 'exitfunc'):  # py 2.x
         try:
             # Calling epicsExit() will bypass any atexit exit handlers, so call
             # them explicitly now.
@@ -48,12 +51,13 @@ def safeEpicsExit(code=0):
             # Make sure we don't try the exit handlers more than once!
             del sys.exitfunc
 
-    elif hasattr(atexit, '_run_exitfuncs'): # py 3.x
+    elif hasattr(atexit, '_run_exitfuncs'):  # py 3.x
         atexit._run_exitfuncs()
 
     # calls epicsExitCallAtExits()
     # and then OS exit()
-    epicsExit(code)
+    imports.epicsExit(code)
+epicsExit = safeEpicsExit
 
 # The following identifiers will be exported to interactive shell.
 command_names = []
@@ -240,10 +244,10 @@ and any other value means yes.''',
 # Hacked up exit object so that when soft IOC framework sends us an exit command
 # we actually exit.
 class Exiter:
-    def __repr__(self):
-        safeEpicsExit()
-    def __call__(self):
-        safeEpicsExit()
+    def __repr__(self):  # hack to exit when "called" with no parenthesis
+        sys.exit(0)
+    def __call__(self, code=0):
+        sys.exit(code)
 
 exit = Exiter()
 command_names.append('exit')
@@ -312,7 +316,12 @@ def interactive_ioc(context = {}, call_exit = True):
         # This suppresses irritating exit message introduced by Python3.  Alas,
         # this option is only available in Python 3.6!
         interact_args = dict(exitmsg = '')
-    code.interact(local = dict(exports, **context), **interact_args)
+    try:
+        code.interact(local = dict(exports, **context), **interact_args)
+    except SystemExit as e:
+        if call_exit:
+            safeEpicsExit(e.code)
+        raise
 
     if call_exit:
-        safeEpicsExit()
+        safeEpicsExit(0)


### PR DESCRIPTION
1. Add argument to `epicsExit(int)` to avoid exit with ~random code.
2. Add call to `atexit._run_exitfuncs()` with py 3.x
3. Cleanup/exit cleanly with `interactive_ioc(call_exit=False)`
