### PR TITLE
Only use the calculated length if NELM was NOT provided during record creation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.testing.pytestArgs": [],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -298,9 +298,10 @@ All functions return a wrapped `ProcessDeviceSupportIn` or
 
     If ``value`` is specified or if an `initial_value` is specified (only one of
     these can be used) the value is used to initialise the waveform and to
-    determine its field type and length.  If no initial value is specified then
-    the keyword argument ``length`` must be used to specify the length of the
-    waveform.
+    determine its field type and length (the inferred values may be overridden using 
+    keywords ``datatype`` and ``NELM`` respectively).  If no initial value is specified 
+    then the keyword argument ``length`` (or ``NELM``) must be used to specify the 
+    length of the waveform.
 
     The field type can be explicitly specified either by setting the ``datatype``
     keyword to a Python type name, or by setting ``FTVL`` to the appropriate EPICS

--- a/softioc/builder.py
+++ b/softioc/builder.py
@@ -169,7 +169,9 @@ def _waveform(value, fields):
     # If NELM has been explicitly set use that, otherwise use computed length
     if 'NELM' not in fields:
         fields['NELM'] = length
-    
+    elif fields['NELM'] < length:
+        raise ValueError("NELM value shorter than value length")
+
     fields.setdefault('FTVL', FTVL)
 
 

--- a/softioc/builder.py
+++ b/softioc/builder.py
@@ -166,7 +166,10 @@ def _waveform(value, fields):
             'Can\'t specify FTVL and datatype together'
         FTVL = NumpyCharCodeToFtvl[numpy.dtype(datatype).char]
 
-    fields['NELM'] = length
+    # If NELM has been explicitly set use that, otherwise use computed length
+    if 'NELM' not in fields:
+        fields['NELM'] = length
+    
     fields.setdefault('FTVL', FTVL)
 
 

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -4,7 +4,7 @@ import pytest
 from softioc import builder
 
 import sim_records
-
+import numpy
 
 def test_records(tmp_path):
     path = str(tmp_path / "records.db")
@@ -13,8 +13,18 @@ def test_records(tmp_path):
     assert open(path).readlines()[5:] == open(expected).readlines()
 
 def test_enum_length_restriction():
+    """Test that supplying too many labels (more than maximum of 16) raises expected
+    exception"""
     with pytest.raises(AssertionError):
         builder.mbbIn(
                 "ManyLabels", "one", "two", "three", "four", "five", "six",
                 "seven", "eight", "nine", "ten", "eleven", "twelve", "thirteen",
                 "fourteen", "fifteen", "sixteen", "seventeen")
+
+
+def test__waveform_fields_nelm_used():
+    """Test that the waveform construction returns the expected fields - i.e. NELM
+    is the same as the input value. Test for issue #37"""
+    fields = {"initial_value": numpy.array([1, 2, 3]), "NELM": 999}
+    builder._waveform(None, fields)
+    assert fields["NELM"] == 999


### PR DESCRIPTION
Closes #37 

This PR is what I think the minimum fix is for the linked issue - it allows setting both `initial_value` and `NELM` during waveform record creation such that both keywords are respected.

It does not currently attempt to do anything regarding the "duplicate" `length` vs `NELM` or `value` vs `initial_value` keyword arguments. Using "mixed pairs" of Python and EPICS keywords will not work in all cases. Please let me know what, if anything, I should do with that.

A single test is written to cover the one case I originally identified - depending on the outcome of discussion I can write more, as appropriate.