### PR TITLE
Provide logging for exceptions raised in callbacks

### DIFF
--- a/softioc/asyncio_dispatcher.py
+++ b/softioc/asyncio_dispatcher.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import logging
 import threading
 import atexit
 
@@ -28,7 +29,10 @@ class AsyncioDispatcher:
 
     def __call__(self, func, *args):
         async def async_wrapper():
-            ret = func(*args)
-            if inspect.isawaitable(ret):
-                await ret
+            try:
+                ret = func(*args)
+                if inspect.isawaitable(ret):
+                    await ret
+            except Exception:
+                logging.exception("Exception when awaiting callback")
         asyncio.run_coroutine_threadsafe(async_wrapper(), self.loop)


### PR DESCRIPTION
This PR fixes the problem that exceptions which escape from an `on_update`/ `on_update_name` callback are silently ignored and never printed. As discussed with @Araneidae and @thomascobb the `AsyncioDispatcher` needs some logging to handle this case.

No Docs changes as it's now safe to let Exceptions escape the callbacks, which I don't think warrants explicit documentation. Happy to write a few lines if you think it is.

No tests as the `AsyncioDispatcher.__call__()` method provides no way to `await` the completion of the passed callback, and so logging cannot be captured. Manual testing shows the error message, exception, and stack trace in stderr as expected.