### PR TITLE
Fix main for Python2

### DIFF
--- a/softioc/__main__.py
+++ b/softioc/__main__.py
@@ -9,12 +9,17 @@ from . import __version__
 def main(args=None):
     parser = ArgumentParser()
     parser.add_argument("--version", action="version", version=__version__)
-    parser.add_argument("script", help="The python script to run")
+    parser.add_argument(
+        "script", help="The python script to run", nargs="?", default=None)
     parser.add_argument(
         "arg", help="Any arguments to pass to the script", nargs="*")
-    parsed_args = parser.parse_args(args)
-    # Execute as subprocess
-    cmd = [sys.executable, parsed_args.script] + parsed_args.arg
+    parsed_args, unknown = parser.parse_known_args(args)
+
+    # Execute as subprocess.
+    cmd = [sys.executable] + parsed_args.arg + unknown
+    if parsed_args.script:
+        cmd.insert(1, parsed_args.script)
+
     subprocess.Popen(cmd).communicate()
 
 

--- a/softioc/__main__.py
+++ b/softioc/__main__.py
@@ -3,7 +3,7 @@ import sys
 from argparse import ArgumentParser
 import subprocess
 
-from softioc import __version__
+from . import __version__
 
 
 def main(args=None):
@@ -14,7 +14,7 @@ def main(args=None):
         "arg", help="Any arguments to pass to the script", nargs="*")
     parsed_args = parser.parse_args(args)
     # Execute as subprocess
-    cmd = [sys.executable, parsed_args.script, *parsed_args.arg]
+    cmd = [sys.executable, parsed_args.script] + parsed_args.arg
     subprocess.Popen(cmd).communicate()
 
 


### PR DESCRIPTION
Fix the main function for Python2. When this is merged a new release should be done.

Note the version import change is not strictly required, it's just a fix for cases when `__main__` has been imported by someone else, which caused the import to pick up `softioc.py` instead of the module itself. This happens using `virtualenv` with its startup script. 

Closes #62 
Closes #59 