### PR TITLE
Default DISP to TRUE for all In records

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,12 +5,21 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        },
+        {
             "name": "Debug Unit Test",
             "type": "python",
             "request": "launch",
             "justMyCode": false,
             "program": "${file}",
-            "purpose": ["debug-test"],
+            "purpose": [
+                "debug-test"
+            ],
             "console": "integratedTerminal",
             "env": {
                 // The default config in setup.cfg's "[tool:pytest]" adds coverage.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased_
 Changed:
 
 - `Remove python2 support <../../pull/64>`
+- `Default DISP to TRUE for all In records <../../pull/74>`
 
 3.2.1_ - 2021-11-25
 -------------------

--- a/softioc/builder.py
+++ b/softioc/builder.py
@@ -18,12 +18,13 @@ PythonDevice = pythonSoftIoc.PythonDevice()
 
 
 def _in_record(record, name, **fields):
-    '''For input records we provide some automatic extra features: scanning
-    and initialisation as appropriate.'''
+    '''For input records we provide some automatic extra features: scanning,
+    initialisation as appropriate, and blocking puts from outside the IOC.'''
 
     fields.setdefault('SCAN', 'I/O Intr')
     if 'initial_value' in fields:
         fields.setdefault('PINI', 'YES')
+    fields.setdefault('DISP', 1)
     return getattr(PythonDevice, record)(name, **fields)
 
 

--- a/tests/expected_records.db
+++ b/tests/expected_records.db
@@ -1,5 +1,6 @@
 record(ai, "TS-DI-TEST-01:AI")
 {
+    field(DISP, "1")
     field(DTYP, "Python")
     field(INP,  "@TS-DI-TEST-01:AI")
     field(PINI, "YES")
@@ -14,6 +15,7 @@ record(ao, "TS-DI-TEST-01:AO")
 
 record(bi, "TS-DI-TEST-01:BOOLIN")
 {
+    field(DISP, "1")
     field(DTYP, "Python")
     field(INP,  "@TS-DI-TEST-01:BOOLIN")
     field(ONAM, "False")
@@ -33,6 +35,7 @@ record(bo, "TS-DI-TEST-01:BOOLOUT")
 
 record(longin, "TS-DI-TEST-01:LONGIN")
 {
+    field(DISP, "1")
     field(DTYP, "Python")
     field(INP,  "@TS-DI-TEST-01:LONGIN")
     field(MDEL, "-1")
@@ -49,6 +52,7 @@ record(longout, "TS-DI-TEST-01:LONGOUT")
 
 record(waveform, "TS-DI-TEST-01:LONGSTRING")
 {
+    field(DISP, "1")
     field(DTYP, "Python")
     field(FTVL, "UCHAR")
     field(INP,  "@TS-DI-TEST-01:LONGSTRING")
@@ -58,6 +62,7 @@ record(waveform, "TS-DI-TEST-01:LONGSTRING")
 
 record(mbbi, "TS-DI-TEST-01:MBBI")
 {
+    field(DISP, "1")
     field(DTYP, "Python")
     field(INP,  "@TS-DI-TEST-01:MBBI")
     field(ONST, "Two")
@@ -87,6 +92,7 @@ record(mbbo, "TS-DI-TEST-01:MBBO")
 
 record(waveform, "TS-DI-TEST-01:SIN")
 {
+    field(DISP, "1")
     field(DTYP, "Python")
     field(FTVL, "DOUBLE")
     field(INP,  "@TS-DI-TEST-01:SIN")
@@ -111,6 +117,7 @@ record(ao, "TS-DI-TEST-01:SINP")
 
 record(stringin, "TS-DI-TEST-01:STRINGIN")
 {
+    field(DISP, "1")
     field(DTYP, "Python")
     field(INP,  "@TS-DI-TEST-01:STRINGIN")
     field(PINI, "YES")
@@ -125,6 +132,7 @@ record(stringout, "TS-DI-TEST-01:STRINGOUT")
 
 record(waveform, "TS-DI-TEST-01:WAVEFORM")
 {
+    field(DISP, "1")
     field(DTYP, "Python")
     field(FTVL, "DOUBLE")
     field(INP,  "@TS-DI-TEST-01:WAVEFORM")
@@ -135,6 +143,7 @@ record(waveform, "TS-DI-TEST-01:WAVEFORM")
 
 record(waveform, "TS-DI-TEST-01:WAVEFORM2")
 {
+    field(DISP, "1")
     field(DTYP, "Python")
     field(FTVL, "FLOAT")
     field(INP,  "@TS-DI-TEST-01:WAVEFORM2")

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -18,3 +18,36 @@ def test_enum_length_restriction():
                 "ManyLabels", "one", "two", "three", "four", "five", "six",
                 "seven", "eight", "nine", "ten", "eleven", "twelve", "thirteen",
                 "fourteen", "fifteen", "sixteen", "seventeen")
+
+def test_DISP_defaults_on():
+    """Test that all IN record types have DISP=1 set by default"""
+    in_records = [
+        builder.aIn,
+        builder.boolIn,
+        builder.longIn,
+        builder.mbbIn,
+        builder.stringIn,
+        builder.WaveformIn,
+    ]
+
+    record_counter = 0
+
+    for creation_func in in_records:
+        kwargs = {}
+        record_counter += 1
+        record_name = "DISP" + str(record_counter)
+
+        if creation_func == builder.WaveformIn:
+            kwargs = {"length": 1}
+
+        record = creation_func(record_name, **kwargs)
+
+        # Note: DISP attribute won't exist if field not specified
+        assert record.DISP.Value() == 1
+
+def test_DISP_can_be_overridden():
+    """Test that DISP can be forced off for In records"""
+
+    record = builder.longIn("DISP-OFF", DISP=0)
+    # Note: DISP attribute won't exist if field not specified
+    assert record.DISP.Value() == 0


### PR DESCRIPTION
This PR will default the `DISP` field to `TRUE` for all In record types.

PythonSoftIOC In records never perform processing, and so are never given an opportunity to access the .VAL field, even if a `caput` has updated it. This means that while a `caget` call would return the new value, a `record.get()` call would not which would lead to confusion.

By setting DISP=TRUE we disable `caput` from changing the value and thus maintaining consistency between `caget` and `record.get()` values.

Note that it is possible to use `caput` to change the DISP field, but if users do this it's on them. I'm not sure there's any way to stop them doing this if they really want to.

This could be a breaking change, depending how well behaved people have been with In records. @MJGaughran gave the example of an In record being used as an input to a CALC record. And of course the more general use-case of someone just doing `caput` to an In record, when they probably should have been using an Out record.