### PR TITLE
Move iocStats into softioc dir

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -93,8 +93,6 @@ jobs:
       - name: Build Wheel
         run: cibuildwheel --output-dir dist
         env:
-          # Force old behaviour of pip - see https://github.com/pypa/cibuildwheel/issues/962
-          CIBW_ENVIRONMENT: PIP_USE_DEPRECATED=out-of-tree-build
           CIBW_BUILD: ${{ matrix.python }}*64
           CIBW_TEST_EXTRAS: dev
           CIBW_TEST_COMMAND: pytest {project}/tests --cov-report xml:${{ matrix.cov_file }} --junit-xml=${{ matrix.results_file }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "iocStats"]
-	path = iocStats
+	path = softioc/iocStats
 	url = https://github.com/epics-modules/iocStats.git

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,14 @@ console_scripts =
 softioc =
     access.acf
     device.dbd
-    devIocStats.dbd
-    iocStatsDb/*
+    iocStats/devIocStats/*
+    iocStats/iocAdmin/Db/*
+    # Include the OS specific files in the sdist, even
+    # if not packages by setup.py (as we only build sdist on one arch)
+    iocStats/devIocStats/os/default/*
+    iocStats/devIocStats/os/Darwin/*
+    iocStats/devIocStats/os/WIN32/*
+    iocStats/devIocStats/os/Linux/*
 
 [options.extras_require]
 # Useful extras for use at DLS
@@ -47,15 +53,6 @@ dev =
     aioca >=1.3
     cothread; sys_platform != "win32"
     p4p
-
-# Include the OS specific files in the sdist, even
-# if not packages by setup.py (as we only build sdist on one arch)
-[options.data_files]
-iocStats/devIocStats = iocStats/devIocStats/*.c, iocStats/devIocStats/*.h
-iocStats/devIocStats/os/default = iocStats/devIocStats/os/default/*
-iocStats/devIocStats/os/Darwin = iocStats/devIocStats/os/Darwin/*
-iocStats/devIocStats/os/WIN32 = iocStats/devIocStats/os/WIN32/*
-iocStats/devIocStats/os/Linux = iocStats/devIocStats/os/Linux/*
 
 [flake8]
 max-line-length = 80

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ devIocStats_OSD = [
     "osdPIDInfo.c",
 ]
 
-devIocStats_src = os.path.join("iocStats", "devIocStats")
+devIocStats_src = os.path.join("softioc", "iocStats", "devIocStats")
 devIocStats_os = os.path.join(devIocStats_src, "os", get_config_var('OS_CLASS'))
 devIocStats_default = os.path.join(devIocStats_src, "os", "default")
 

--- a/softioc/__init__.py
+++ b/softioc/__init__.py
@@ -19,7 +19,8 @@ from ._version_git import __version__
 iocshRegisterCommon()
 for dbd in ('base.dbd', 'PVAServerRegister.dbd', 'qsrv.dbd'):
     dbLoadDatabase(dbd, os.path.join(path.base_path, 'dbd'), None)
-dbLoadDatabase('devIocStats.dbd', os.path.dirname(__file__), None)
+iocStats = os.path.join(os.path.dirname(__file__), "iocStats", "devIocStats")
+dbLoadDatabase('devIocStats.dbd', iocStats, None)
 
 if registerRecordDeviceDriver(pdbbase):
     raise RuntimeError('Error registering')

--- a/softioc/devIocStats.dbd
+++ b/softioc/devIocStats.dbd
@@ -1,1 +1,0 @@
-../iocStats/devIocStats/devIocStats.dbd

--- a/softioc/iocStatsDb
+++ b/softioc/iocStatsDb
@@ -1,1 +1,0 @@
-../iocStats/iocAdmin/Db

--- a/softioc/softioc.py
+++ b/softioc/softioc.py
@@ -292,7 +292,8 @@ def devIocStats(ioc_name):
     '''This will load a template for the devIocStats library with the specified
     IOC name. This should be called before `iocInit`'''
     substitutions = 'IOCNAME=' + ioc_name + ', TODFORMAT=%m/%d/%Y %H:%M:%S'
-    iocstats_dir = os.path.join(os.path.dirname(__file__), 'iocStatsDb')
+    iocstats_dir = os.path.join(
+        os.path.dirname(__file__), 'iocStats', 'iocAdmin', 'Db')
     _add_records_from_file(iocstats_dir, 'ioc.template', substitutions)
 
 


### PR DESCRIPTION
This means no more softlinks, so CI works again without the deprecated (and now removed) pip out of tree build.

Fixes #90 when I've made a 4.0.2 release