### PR TITLE
Check AsyncioDispatcher loop is running

### DIFF
--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -134,6 +134,8 @@ Test Facilities`_ documentation for more details of each function.
     If your application uses `asyncio` then this module gives an alternative
     dispatcher for caput requests.
 
+.. autoclass:: softioc.asyncio_dispatcher.AsyncioDispatcher
+
 .. automodule:: softioc.builder
 
     Creating Records: `softioc.builder`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ class SubprocessIOC:
         if self.proc.returncode is None:
             # still running, kill it and print the output
             self.proc.kill()
-            out, err = self.proc.communicate()
+            out, err = self.proc.communicate(timeout=TIMEOUT)
             print(out.decode())
             print(err.decode())
 

--- a/tests/sim_asyncio_ioc.py
+++ b/tests/sim_asyncio_ioc.py
@@ -9,15 +9,14 @@ from softioc import alarm, softioc, builder, asyncio_dispatcher, pvlog
 from conftest import ADDRESS, select_and_recv
 
 if __name__ == "__main__":
-    # Being run as an IOC, so parse args and set prefix
-    parser = ArgumentParser()
-    parser.add_argument('prefix', help="The PV prefix for the records")
-    parsed_args = parser.parse_args()
-    builder.SetDeviceName(parsed_args.prefix)
-
-    import sim_records
-
     with Client(ADDRESS) as conn:
+        # Being run as an IOC, so parse args and set prefix
+        parser = ArgumentParser()
+        parser.add_argument('prefix', help="The PV prefix for the records")
+        parsed_args = parser.parse_args()
+        builder.SetDeviceName(parsed_args.prefix)
+
+        import sim_records
 
         async def callback(value):
             # Set the ao value, which will trigger on_update for it

--- a/tests/sim_asyncio_ioc_override.py
+++ b/tests/sim_asyncio_ioc_override.py
@@ -7,38 +7,42 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from argparse import ArgumentParser
 from multiprocessing.connection import Client
+import threading
 
 from softioc import softioc, builder, asyncio_dispatcher
 
 from conftest import ADDRESS, select_and_recv
 
 if __name__ == "__main__":
-    # Being run as an IOC, so parse args and set prefix
-    parser = ArgumentParser()
-    parser.add_argument('prefix', help="The PV prefix for the records")
-    parsed_args = parser.parse_args()
-    builder.SetDeviceName(parsed_args.prefix)
-
-    # Load the base records without DTYP fields
-    with open(Path(__file__).parent / "hw_records.db", "rb") as inp:
-        with NamedTemporaryFile(suffix='.db', delete=False) as out:
-            for line in inp.readlines():
-                if not re.match(rb"\s*field\s*\(\s*DTYP", line):
-                    out.write(line)
-    softioc.dbLoadDatabase(
-        out.name, substitutions=f"device={parsed_args.prefix}")
-    os.unlink(out.name)
-
-    # Override DTYPE and OUT, and provide a callback
-    gain = builder.boolOut("GAIN", on_update=print)
-    softioc.devIocStats(parsed_args.prefix)
-
-    # Run the IOC
-    builder.LoadDatabase()
-    event_loop = asyncio.get_event_loop()
-    softioc.iocInit(asyncio_dispatcher.AsyncioDispatcher(event_loop))
-
     with Client(ADDRESS) as conn:
+        # Being run as an IOC, so parse args and set prefix
+        parser = ArgumentParser()
+        parser.add_argument('prefix', help="The PV prefix for the records")
+        parsed_args = parser.parse_args()
+        builder.SetDeviceName(parsed_args.prefix)
+
+        # Load the base records without DTYP fields
+        with open(Path(__file__).parent / "hw_records.db", "rb") as inp:
+            with NamedTemporaryFile(suffix='.db', delete=False) as out:
+                for line in inp.readlines():
+                    if not re.match(rb"\s*field\s*\(\s*DTYP", line):
+                        out.write(line)
+        softioc.dbLoadDatabase(
+            out.name, substitutions=f"device={parsed_args.prefix}")
+        os.unlink(out.name)
+
+        # Override DTYPE and OUT, and provide a callback
+        gain = builder.boolOut("GAIN", on_update=print)
+        softioc.devIocStats(parsed_args.prefix)
+
+        # Run the IOC
+        builder.LoadDatabase()
+        event_loop = asyncio.get_event_loop()
+        worker = threading.Thread(target=event_loop.run_forever)
+        worker.daemon = True
+        worker.start()
+        softioc.iocInit(asyncio_dispatcher.AsyncioDispatcher(event_loop))
+
         conn.send("R")  # "Ready"
 
         # Make sure coverage is written on epicsExit

--- a/tests/sim_cothread_ioc.py
+++ b/tests/sim_cothread_ioc.py
@@ -7,21 +7,21 @@ from softioc import softioc, builder, pvlog
 from conftest import ADDRESS, select_and_recv
 
 if __name__ == "__main__":
-    import cothread
-
-    # Being run as an IOC, so parse args and set prefix
-    parser = ArgumentParser()
-    parser.add_argument('prefix', help="The PV prefix for the records")
-    parsed_args = parser.parse_args()
-    builder.SetDeviceName(parsed_args.prefix)
-
-    import sim_records
-
-    # Run the IOC
-    builder.LoadDatabase()
-    softioc.iocInit()
-
     with Client(ADDRESS) as conn:
+        import cothread
+
+        # Being run as an IOC, so parse args and set prefix
+        parser = ArgumentParser()
+        parser.add_argument('prefix', help="The PV prefix for the records")
+        parsed_args = parser.parse_args()
+        builder.SetDeviceName(parsed_args.prefix)
+
+        import sim_records
+
+        # Run the IOC
+        builder.LoadDatabase()
+        softioc.iocInit()
+
         conn.send("R")  # "Ready"
 
         select_and_recv(conn, "D")  # "Done"

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1,9 +1,12 @@
+import asyncio
 import pytest
 import sys
 
 from multiprocessing.connection import Listener
 
 from conftest import requires_cothread, ADDRESS, select_and_recv
+
+from softioc.asyncio_dispatcher import AsyncioDispatcher
 
 @pytest.mark.asyncio
 async def test_asyncio_ioc(asyncio_ioc):
@@ -112,3 +115,10 @@ async def test_asyncio_ioc_override(asyncio_ioc_override):
         print("Out:", out)
         print("Err:", err)
         raise
+
+def test_asyncio_dispatcher_event_loop():
+    """Test that passing a non-running event loop to the AsyncioDispatcher
+    raises an exception"""
+    event_loop = asyncio.get_event_loop()
+    with pytest.raises(ValueError):
+        AsyncioDispatcher(loop=event_loop)


### PR DESCRIPTION
Also added documentation.
Also fixed potential permanent block in tests - if the subprocess never creates its Client, the parent process blocks forever on an accept().
This was the case in the asyncio_ioc_override, where initialization was failing due to non-running loop.

Closes #95.