### PR TITLE
Caput with callback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Versioning <https://semver.org/spec/v2.0.0.html>`_.
 Unreleased_
 -----------
 
+Added:
+
+- `Caput with callback <../../pull/98>`_
+
 Fixed:
 
 - `Passing a custom asyncio event loop into the AsyncioDispatcher causes methods to never run <../../pull/96>`_

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -228,6 +228,23 @@ Test Facilities`_ documentation for more details of each function.
     which don't change its value will be discarded.  In particular this means
     that such updates don't call `validate` or `on_update`.
 
+    .. _blocking:
+
+    `blocking`
+    ~~~~~~~~~~
+
+    Only available on OUT records. When set to `True` the record will set the
+    ``PACT`` field when processing is ongoing. This means that ``caput`` and
+    similar tools can correctly wait for processing to complete.
+
+    This flag defaults to `False`, to retain compatibility with previous
+    versions.
+
+    .. seealso::
+        `SetBlocking` for configuring a global default blocking value
+
+
+
 For all of these functions any EPICS database field can be assigned a value by
 passing it as a keyword argument for the corresponding field name (in upper
 case) or by assigning to the corresponding field of the returned record object.
@@ -357,6 +374,17 @@ record creation function.
     This can optionally be called after completing the creation of records to
     prevent the accidential creation of records with the currently set device
     name.
+
+.. function:: SetBlocking(blocking)
+
+    This can be used to globally set the default `blocking` flag, which will
+    apply to all records created after this point. This allows blocking to be
+    easily set/unset when creating groups of records.
+
+    This does not change the blocking value for any already created records.
+
+    .. seealso::
+        `blocking` for description of the flag
 
 
 The following helper functions are useful when constructing links between

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -377,9 +377,15 @@ record creation function.
 
 .. function:: SetBlocking(blocking)
 
-    This can be used to globally set the default `blocking` flag, which will
-    apply to all records created after this point. This allows blocking to be
+    This can be used to globally set the default of the `blocking` flag, which
+    will apply to all records created after this point. This allows blocking to be
     easily set/unset when creating groups of records.
+
+    Returns the previous value of the `blocking` flag, which enables code like this::
+
+        old_blocking = SetBlocking(new_blocking)
+        create_records()
+        SetBlocking(old_blocking)
 
     This does not change the blocking value for any already created records.
 

--- a/softioc/asyncio_dispatcher.py
+++ b/softioc/asyncio_dispatcher.py
@@ -32,18 +32,19 @@ class AsyncioDispatcher:
         else:
             self.loop = loop
 
-    def __call__(self, func, completion, func_args=(), completion_args=()):
+    def __call__(
+            self,
+            func,
+            func_args=(),
+            completion = None,
+            completion_args=()):
         async def async_wrapper():
             try:
-                if inspect.iscoroutinefunction(func):
-                    await func(*func_args)
-                else:
-                    ret = func(*func_args)
-                    # Handle the case of a synchronous function that returns a
-                    # coroutine, like the lambda for on_update_name does
-                    if inspect.isawaitable(ret):
-                        await ret
-                completion(*completion_args)
+                ret = func(*func_args)
+                if inspect.isawaitable(ret):
+                    await ret
+                if completion:
+                    completion(*completion_args)
             except Exception:
                 logging.exception("Exception when awaiting callback")
         asyncio.run_coroutine_threadsafe(async_wrapper(), self.loop)

--- a/softioc/builder.py
+++ b/softioc/builder.py
@@ -9,7 +9,7 @@ LoadDbdFile(os.path.join(os.path.dirname(__file__), 'device.dbd'))
 
 from . import device, pythonSoftIoc  # noqa
 # Re-export this so users only have to import the builder
-from .device import set_blocking # noqa
+from .device import SetBlocking # noqa
 
 PythonDevice = pythonSoftIoc.PythonDevice()
 
@@ -305,5 +305,5 @@ __all__ = [
     'LoadDatabase',
     'SetDeviceName', 'UnsetDevice',
     # Device support functions
-    'set_blocking'
+    'SetBlocking'
 ]

--- a/softioc/builder.py
+++ b/softioc/builder.py
@@ -8,6 +8,8 @@ InitialiseDbd()
 LoadDbdFile(os.path.join(os.path.dirname(__file__), 'device.dbd'))
 
 from . import device, pythonSoftIoc  # noqa
+# Re-export this so users only have to import the builder
+from .device import set_blocking # noqa
 
 PythonDevice = pythonSoftIoc.PythonDevice()
 
@@ -301,5 +303,7 @@ __all__ = [
     'Action',
     # Other builder support functions
     'LoadDatabase',
-    'SetDeviceName', 'UnsetDevice'
+    'SetDeviceName', 'UnsetDevice',
+    # Device support functions
+    'set_blocking'
 ]

--- a/softioc/cothread_dispatcher.py
+++ b/softioc/cothread_dispatcher.py
@@ -10,8 +10,14 @@ class CothreadDispatcher:
         # processing doesn't interfere with other callback processing.
         self.__dispatcher = cothread.cothread._Callback()
 
-    def __call__(self, func, completion, func_args=(), completion_args=()):
+    def __call__(
+            self,
+            func,
+            func_args=(),
+            completion = None,
+            completion_args=()):
         def wrapper():
             func(*func_args)
-            completion(*completion_args)
+            if completion:
+                completion(*completion_args)
         self.__dispatcher(wrapper)

--- a/softioc/cothread_dispatcher.py
+++ b/softioc/cothread_dispatcher.py
@@ -1,0 +1,17 @@
+
+class CothreadDispatcher:
+    def __init__(self):
+        """A dispatcher for `cothread` based IOCs, suitable to be passed to
+        `softioc.iocInit`. """
+        # Import here to ensure we don't instantiate any of cothread's global
+        # state unless we have to
+        import cothread
+        # Create our own cothread callback queue so that our callbacks
+        # processing doesn't interfere with other callback processing.
+        self.__dispatcher = cothread.cothread._Callback()
+
+    def __call__(self, func, completion, func_args=(), completion_args=()):
+        def wrapper():
+            func(*func_args)
+            completion(*completion_args)
+        self.__dispatcher(wrapper)

--- a/softioc/device.py
+++ b/softioc/device.py
@@ -27,8 +27,7 @@ dispatcher = None
 # Default False to maintain behaviour from previous versions.
 blocking = False
 
-# TODO: Docs and Tests for the Blocking feature
-def set_blocking(val):
+def SetBlocking(val):
     global blocking
     blocking = val
 

--- a/softioc/extension.c
+++ b/softioc/extension.c
@@ -215,17 +215,13 @@ static PyObject *install_pv_logging(PyObject *self, PyObject *args)
 
 static void capsule_destructor(PyObject *obj)
 {
-    void *callback = PyCapsule_GetPointer(obj, CAPSULE_NAME);
-    free(callback);
+    free(PyCapsule_GetPointer(obj, CAPSULE_NAME));
 }
 
 
 static PyObject *create_callback_capsule(PyObject *self, PyObject *args)
 {
     void *callback = malloc(sizeof(CALLBACK));
-
-    printf("Created CALLBACK struct %p\n", callback);
-
     return PyCapsule_New(callback, CAPSULE_NAME, &capsule_destructor);
 }
 
@@ -238,6 +234,14 @@ static PyObject *signal_processing_complete(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "inO", &priority, &record, &callback_capsule))
     {
         return NULL;
+    }
+
+    if (!PyCapsule_IsValid(callback_capsule, CAPSULE_NAME))
+    {
+        return PyErr_Format(
+            PyExc_TypeError,
+            "Given object was not a capsule with name \"%s\"",
+            CAPSULE_NAME);
     }
 
     CALLBACK *callback = PyCapsule_GetPointer(callback_capsule, CAPSULE_NAME);

--- a/softioc/imports.py
+++ b/softioc/imports.py
@@ -27,6 +27,17 @@ def install_pv_logging(acf_file):
     '''Install pv logging'''
     _extension.install_pv_logging(acf_file)
 
+def create_callback_capsule():
+    return _extension.create_callback_capsule()
+
+def signal_processing_complete(record, callback):
+    '''Signal that asynchronous record processing has completed'''
+    _extension.signal_processing_complete(
+        record.PRIO,
+        record.record.value,
+        callback
+    )
+
 def expect_success(status, function, args):
     assert status == 0, 'Expected success'
 
@@ -94,6 +105,8 @@ epicsExitCallAtExits.restype = None
 
 __all__ = [
     'get_field_offsets',
+    'create_callback_capsule',
+    'signal_processing_complete',
     'registryDeviceSupportAdd',
     'IOSCANPVT', 'scanIoRequest', 'scanIoInit',
     'dbLoadDatabase',

--- a/softioc/imports.py
+++ b/softioc/imports.py
@@ -35,8 +35,7 @@ def signal_processing_complete(record, callback):
     _extension.signal_processing_complete(
         record.PRIO,
         record.record.value,
-        callback
-    )
+        callback)
 
 def expect_success(status, function, args):
     assert status == 0, 'Expected success'

--- a/softioc/pythonSoftIoc.py
+++ b/softioc/pythonSoftIoc.py
@@ -24,7 +24,7 @@ class RecordWrapper(object):
         # have to maintain this separately from the corresponding device list.
         DeviceKeywords = [
             'on_update', 'on_update_name', 'validate', 'always_update',
-            'initial_value', '_wf_nelm', '_wf_dtype']
+            'initial_value', '_wf_nelm', '_wf_dtype', 'blocking']
         device_kargs = {}
         for keyword in DeviceKeywords:
             if keyword in fields:

--- a/softioc/softioc.py
+++ b/softioc/softioc.py
@@ -7,6 +7,7 @@ from tempfile import NamedTemporaryFile
 from epicsdbbuilder.recordset import recordset
 
 from . import imports, device
+from . import cothread_dispatcher
 
 __all__ = ['dbLoadDatabase', 'iocInit', 'interactive_ioc']
 
@@ -31,10 +32,7 @@ def iocInit(dispatcher=None):
     '''
     if dispatcher is None:
         # Fallback to cothread
-        import cothread
-        # Create our own cothread callback queue so that our callbacks
-        # processing doesn't interfere with other callback processing.
-        dispatcher = cothread.cothread._Callback()
+        dispatcher = cothread_dispatcher.CothreadDispatcher()
     # Set the dispatcher for record processing callbacks
     device.dispatcher = dispatcher
     imports.iocInit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,7 @@ def enable_code_coverage():
 def select_and_recv(conn, expected_char = None):
     """Wait for the given Connection to have data to receive, and return it.
     If a character is provided check its correct before returning it."""
-    # Must use cothread's select if cothread is prsent, otherwise we'd block
+    # Must use cothread's select if cothread is present, otherwise we'd block
     # processing on all cothread processing. But we don't want to use it
     # unless we have to, as importing cothread can cause issues with forking.
     if "cothread" in sys.modules:

--- a/tests/sim_asyncio_ioc.py
+++ b/tests/sim_asyncio_ioc.py
@@ -36,6 +36,17 @@ if __name__ == "__main__":
         # Create a record to set the alarm
         t_ao = builder.aOut('ALARM', on_update=callback)
 
+        async def on_update_name_callback(value, name):
+            print(name, "value", value)
+
+        builder.longOut(
+            "NAME-CALLBACK",
+            initial_value = 3,
+            always_update=True,
+            on_update_name=on_update_name_callback,
+            blocking=True
+        )
+
         # Run the IOC
         builder.LoadDatabase()
         softioc.iocInit(asyncio_dispatcher.AsyncioDispatcher())

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -39,6 +39,8 @@ async def test_asyncio_ioc(asyncio_ioc):
 
         await caput(pre + ":ALARM", 3, wait=True)
 
+        await caput(pre + ":NAME-CALLBACK", 12, wait=True)
+
         # Confirm the ALARM callback has completed
         select_and_recv(conn, "C")  # "Complete"
 
@@ -68,6 +70,7 @@ async def test_asyncio_ioc(asyncio_ioc):
         assert "%s:ALARM.VAL 0 -> 3" % pre in out
         assert 'on_update %s:AO : 3.0' % pre in out
         assert 'async update 3.0 (23.45)' in out
+        assert "%s:NAME-CALLBACK value 12" % pre in out
         assert 'Starting iocInit' in err
         assert 'iocRun: All initialization complete' in err
     except Exception:

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -14,6 +14,7 @@ from conftest import (
 )
 
 from softioc import asyncio_dispatcher, builder, softioc
+from softioc.device import set_blocking
 
 # Test file for miscellaneous tests related to records
 
@@ -179,6 +180,35 @@ def test_pini_always_on():
     mbbi = builder.mbbIn("BBB", initial_value=5)
     assert mbbi.PINI.Value() == "YES"
 
+
+def check_record_blocking_attributes(record):
+    """Helper function to assert expected attributes exist for a blocking
+    record"""
+    assert record._blocking is True
+    assert record._callback != 0
+
+def test_blocking_creates_attributes():
+    """Test that setting the blocking flag on record creation creates the
+    expected attributes"""
+    ao1 = builder.aOut("OUTREC1", blocking=True)
+    check_record_blocking_attributes(ao1)
+
+    ao2 = builder.aOut("OUTREC2", blocking=False)
+    assert ao2._blocking is False
+
+def test_blocking_global_flag_creates_attributes():
+    """Test that the global blocking flag creates the expected attributes"""
+    set_blocking(True)
+    bo1 = builder.boolOut("OUTREC1")
+
+    check_record_blocking_attributes(bo1)
+
+    set_blocking(False)
+    bo2 = builder.boolOut("OUTREC2")
+    assert bo2._blocking is False
+
+    bo3 = builder.boolOut("OUTREC3", blocking=True)
+    check_record_blocking_attributes(bo3)
 
 
 def validate_fixture_names(params):

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -536,6 +536,20 @@ class TestBlocking:
         bo3 = builder.boolOut("OUTREC3", blocking=True)
         self.check_record_blocking_attributes(bo3)
 
+    def test_blocking_returns_old_state(self):
+        """Test that SetBlocking returns the previously set value"""
+        old_val = SetBlocking(True)
+        assert old_val is False  # Default is False
+
+        old_val = SetBlocking(False)
+        assert old_val is True
+
+        # Test it correctly maintains state when passed the current value
+        old_val = SetBlocking(False)
+        assert old_val is False
+        old_val = SetBlocking(False)
+        assert old_val is False
+
     def blocking_test_func(self, device_name, conn):
 
         builder.SetDeviceName(device_name)

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -16,7 +16,7 @@ from conftest import (
 )
 
 from softioc import asyncio_dispatcher, builder, softioc
-from softioc.device import set_blocking
+from softioc.device import SetBlocking
 
 # Test file for miscellaneous tests related to records
 
@@ -185,6 +185,7 @@ def test_pini_always_on():
 def validate_fixture_names(params):
     """Provide nice names for the out_records fixture in TestValidate class"""
     return params[0].__name__
+
 class TestValidate:
     """Tests related to the validate callback"""
 
@@ -524,11 +525,11 @@ class TestBlocking:
 
     def test_blocking_global_flag_creates_attributes(self):
         """Test that the global blocking flag creates the expected attributes"""
-        set_blocking(True)
+        SetBlocking(True)
         bo1 = builder.boolOut("OUTREC1")
         self.check_record_blocking_attributes(bo1)
 
-        set_blocking(False)
+        SetBlocking(False)
         bo2 = builder.boolOut("OUTREC2")
         assert bo2._blocking is False
 
@@ -576,6 +577,7 @@ class TestBlocking:
 
         log("CHILD: Received exit command, child exiting")
 
+    @requires_cothread
     def test_blocking_single_thread_multiple_calls(self):
         """Test that a blocking record correctly causes multiple caputs from
         a single thread to wait for the expected time"""


### PR DESCRIPTION
Add blocking to the processing of `on_update`/`on_update_name` callbacks, to allow `caput` to correctly wait for processing to complete before returning.

Documented the new `blocking` flag on OUT record creation, and the `SetBlocking` function. I didn't document the CothreadDispatcher, as there's no reason for any users to explicitly create it themselves. Let me know if I should document it, or perhaps change its name to indicate its internal-only.

Tests written:
- Various tests that the record-level and global blocking flag are correctly passed to the `ProcessDeviceSupportOut` class
- A blocking record will correctly process blocking `caput` requests from both a single thread multiple times and from multiple threads simultaneously.

