### PR TITLE
Allow arrays of strings to be used with Waveforms

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,8 @@
             "type": "python",
             "request": "launch",
             "program": "${file}",
-            "console": "integratedTerminal"
+            "console": "integratedTerminal",
+            "justMyCode": false,
         },
         {
             "name": "Debug Unit Test",

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Added:
 
 - `Allow "status" and "severity" on In record init <../../pull/111>`_
 - `Allow users to reset the list of created records <../../pull/114>`_
+- `Allow arrays of strings to be used with Waveforms <../../pull/102>`_
 
 4.1.0_ - 2022-08-05
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Added:
 
 Fixed:
 
+- `Allow arrays of strings to be used with Waveforms <../../pull/102>`_
 - `Fix DeprecationWarning from numpy when using "+" <../../pull/123>`_
 
 4.2.0_ - 2022-11-08
@@ -30,7 +31,6 @@ Added:
 
 - `Allow "status" and "severity" on In record init <../../pull/111>`_
 - `Allow users to reset the list of created records <../../pull/114>`_
-- `Allow arrays of strings to be used with Waveforms <../../pull/102>`_
 
 4.1.0_ - 2022-08-05
 -------------------

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -342,6 +342,11 @@ All functions return a wrapped `ProcessDeviceSupportIn` or
     field type name.  Otherwise the field type is taken from the initial value
     if given, or defaults to ``'FLOAT'``.
 
+    .. note::
+        When storing arrays of strings, it is possible to store Unicode characters.
+        However, as EPICS has no Unicode support the resultant values will be stored
+        as byte strings. Care must be taken when encoding/decoding the values.
+
 
 The following functions generates specialised records.
 

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -343,9 +343,9 @@ All functions return a wrapped `ProcessDeviceSupportIn` or
     if given, or defaults to ``'FLOAT'``.
 
     .. note::
-        When storing arrays of strings, it is possible to store Unicode characters.
-        However, as EPICS has no Unicode support the resultant values will be stored
-        as byte strings. Care must be taken when encoding/decoding the values.
+        Storing arrays of strings differs from other values. String arrays will always
+        be assumed to be encoded as Unicode strings, and will be returned to the user
+        as a Python list rather than a Numpy array.
 
 
 The following functions generates specialised records.

--- a/softioc/builder.py
+++ b/softioc/builder.py
@@ -11,7 +11,7 @@ LoadDbdFile(os.path.join(os.path.dirname(__file__), 'device.dbd'))
 
 from . import device, pythonSoftIoc  # noqa
 # Re-export this so users only have to import the builder
-from .device import SetBlocking # noqa
+from .device import SetBlocking, to_epics_str_array # noqa
 
 PythonDevice = pythonSoftIoc.PythonDevice()
 
@@ -148,7 +148,7 @@ NumpyDtypeToDbf = {
     'uint32':   'ULONG',
     'float32':  'FLOAT',
     'float64':  'DOUBLE',
-    'bytes320': 'STRING',  # Numpy's term for a 40-character string (40*8 bits)
+    'bytes320': 'STRING',  # Numpy term for 40-character byte str (40*8 bits)
 }
 
 # Coverts FTVL string to numpy type
@@ -220,8 +220,8 @@ def _waveform(value, fields):
                 initial_value = numpy.require(initial_value, numpy.int32)
             elif initial_value.dtype == numpy.uint64:
                 initial_value = numpy.require(initial_value, numpy.uint32)
-            elif initial_value.dtype.char in ("S", "U"):
-                initial_value = numpy.require(initial_value, numpy.dtype("S40"))
+            elif initial_value.dtype.char in ('S', 'U'):
+                initial_value = to_epics_str_array(initial_value)
     else:
         initial_value = numpy.array([], dtype = datatype)
         length = _get_length(fields)

--- a/softioc/builder.py
+++ b/softioc/builder.py
@@ -148,6 +148,8 @@ NumpyDtypeToDbf = {
     'uint32':   'ULONG',
     'float32':  'FLOAT',
     'float64':  'DOUBLE',
+    'bytes32':  'STRING',
+    'bytes320': 'STRING',
 }
 
 # Coverts FTVL string to numpy type
@@ -160,6 +162,7 @@ DbfStringToNumpy = {
     'ULONG':    'uint32',
     'FLOAT':    'float32',
     'DOUBLE':   'float64',
+    'STRING':   'S40',
 }
 
 
@@ -211,11 +214,15 @@ def _waveform(value, fields):
 
         # Special case for [u]int64: if the initial value comes in as 64 bit
         # integers we cannot represent that, so recast it as [u]int32
+        # Special case for array of strings to correctly identify each element
+        # of the array as a string type.
         if datatype is None:
             if initial_value.dtype == numpy.int64:
                 initial_value = numpy.require(initial_value, numpy.int32)
             elif initial_value.dtype == numpy.uint64:
                 initial_value = numpy.require(initial_value, numpy.uint32)
+            elif initial_value.dtype.char == "S":
+                initial_value = numpy.require(initial_value, numpy.dtype("S40"))
     else:
         initial_value = numpy.array([], dtype = datatype)
         length = _get_length(fields)

--- a/softioc/builder.py
+++ b/softioc/builder.py
@@ -148,8 +148,7 @@ NumpyDtypeToDbf = {
     'uint32':   'ULONG',
     'float32':  'FLOAT',
     'float64':  'DOUBLE',
-    'bytes32':  'STRING',
-    'bytes320': 'STRING',
+    'bytes320': 'STRING',  # Numpy's term for a 40-character string (40*8 bits)
 }
 
 # Coverts FTVL string to numpy type
@@ -214,8 +213,8 @@ def _waveform(value, fields):
 
         # Special case for [u]int64: if the initial value comes in as 64 bit
         # integers we cannot represent that, so recast it as [u]int32
-        # Special case for array of strings to correctly identify each element
-        # of the array as a string type.
+        # Special case for array of strings to mark each element as conforming
+        # to EPICS 40-character string limit
         if datatype is None:
             if initial_value.dtype == numpy.int64:
                 initial_value = numpy.require(initial_value, numpy.int32)

--- a/softioc/builder.py
+++ b/softioc/builder.py
@@ -221,7 +221,7 @@ def _waveform(value, fields):
                 initial_value = numpy.require(initial_value, numpy.int32)
             elif initial_value.dtype == numpy.uint64:
                 initial_value = numpy.require(initial_value, numpy.uint32)
-            elif initial_value.dtype.char == "S":
+            elif initial_value.dtype.char in ("S", "U"):
                 initial_value = numpy.require(initial_value, numpy.dtype("S40"))
     else:
         initial_value = numpy.array([], dtype = datatype)

--- a/softioc/device.py
+++ b/softioc/device.py
@@ -391,6 +391,7 @@ class WaveformBase(ProcessDeviceSupportCore):
         return result
 
     def _write_value(self, record, value):
+        value = _require_waveform(value, self._dtype)
         nord = len(value)
         memmove(
             record.BPTR, value.ctypes.data_as(c_void_p),

--- a/softioc/device.py
+++ b/softioc/device.py
@@ -367,18 +367,18 @@ def to_epics_str_array(value):
 
 
 def _require_waveform(value, dtype):
-    if isinstance(value, bytes):
-        # Special case hack for byte arrays.  Surprisingly tricky:
-        value = numpy.frombuffer(value, dtype = numpy.uint8)
-
     if dtype and dtype.char == 'S':
         return to_epics_str_array(value)
+    else:
+        if isinstance(value, bytes):
+            # Special case hack for byte arrays.  Surprisingly tricky:
+            value = numpy.frombuffer(value, dtype = numpy.uint8)
 
-    value = numpy.require(value, dtype = dtype)
-    if value.shape == ():
-        value.shape = (1,)
-    assert value.ndim == 1, 'Can\'t write multidimensional arrays'
-    return value
+        value = numpy.require(value, dtype = dtype)
+        if value.shape == ():
+            value.shape = (1,)
+        assert value.ndim == 1, 'Can\'t write multidimensional arrays'
+        return value
 
 
 class WaveformBase(ProcessDeviceSupportCore):

--- a/softioc/device.py
+++ b/softioc/device.py
@@ -430,7 +430,10 @@ class WaveformBase(ProcessDeviceSupportCore):
         return numpy.copy(value)
 
     def _epics_to_value(self, value):
-        return value
+        if self._dtype.char == 'S':
+            return [_string_at(s, 40) for s in value]
+        else:
+            return value
 
     def _value_to_dbr(self, value):
         return self._dbf_type_, len(value), value.ctypes.data, value

--- a/softioc/device.py
+++ b/softioc/device.py
@@ -356,6 +356,16 @@ def _require_waveform(value, dtype):
     if isinstance(value, bytes):
         # Special case hack for byte arrays.  Surprisingly tricky:
         value = numpy.frombuffer(value, dtype = numpy.uint8)
+
+    if dtype and dtype.char == 'S':
+        result = numpy.empty(len(value), 'S40')
+        for n, s in enumerate(value):
+            if isinstance(s, str):
+                result[n] = s.encode('UTF-8')
+            else:
+                result[n] = s
+        return result
+
     value = numpy.require(value, dtype = dtype)
     if value.shape == ():
         value.shape = (1,)
@@ -391,7 +401,6 @@ class WaveformBase(ProcessDeviceSupportCore):
         return result
 
     def _write_value(self, record, value):
-        value = _require_waveform(value, self._dtype)
         nord = len(value)
         memmove(
             record.BPTR, value.ctypes.data_as(c_void_p),

--- a/tests/test_record_values.py
+++ b/tests/test_record_values.py
@@ -31,9 +31,6 @@ VERY_LONG_STRING = "This is a fairly long string, the kind that someone " \
     "might think to put into a record that can theoretically hold a huge " \
     "string and so lets test it and prove that shall we?"
 
-# The numpy dtype of all arrays of strings
-NUMPY_DTYPE_STRING = "S40"
-
 
 def record_func_names(fixture_value):
     """Provide a nice name for the record_func fixture"""
@@ -232,6 +229,34 @@ record_values_list = [
         builder.WaveformOut,
         ["123abc", "456def", "7890ghi"],
         ["123abc", "456def", "7890ghi"],
+        list,
+    ),
+    (
+        "wIn_mixed_array_1",
+        builder.WaveformIn,
+        ["123abc", 456, "7890ghi"],
+        ["123abc", "456", "7890ghi"],
+        list,
+    ),
+    (
+        "wOut_mixed_array_1",
+        builder.WaveformOut,
+        ["123abc", 456, "7890ghi"],
+        ["123abc", "456", "7890ghi"],
+        list,
+    ),
+    (
+        "wIn_mixed_array_2",
+        builder.WaveformIn,
+        [123, 456, "7890ghi"],
+        ["123", "456", "7890ghi"],
+        list,
+    ),
+    (
+        "wOut_mixed_array_2",
+        builder.WaveformOut,
+        [123, 456, "7890ghi"],
+        ["123", "456", "7890ghi"],
         list,
     ),
     (
@@ -435,7 +460,7 @@ def run_test_function(
 
         if creation_func in (builder.WaveformIn, builder.WaveformOut):
             if isinstance(initial_value, list) and \
-                    all(isinstance(val, (str, bytes)) for val in initial_value):
+                    any(isinstance(val, (str, bytes)) for val in initial_value):
                 if set_enum is not SetValueEnum.INITIAL_VALUE:
                     print(f"Removing {configuration}")
                     return False
@@ -580,7 +605,7 @@ class TestGetValue:
         if (
             creation_func in [builder.WaveformIn, builder.WaveformOut] and
             isinstance(initial_value, list) and
-            all(isinstance(s, (str, bytes)) for s in initial_value)
+            any(isinstance(s, (str, bytes)) for s in initial_value)
         ):
             pytest.skip("Cannot .set() a list of strings to a waveform, must"
                         "initially specify using initial_value or FTVL")
@@ -974,7 +999,7 @@ class TestInvalidValues:
 
     def test_waveform_rejects_late_strings(self):
         """Test that a waveform won't allow a list of strings to be assigned
-        if no list was given in initial waveform construction"""
+        if no string list was given in initial waveform construction"""
         w_in = builder.WaveformIn("W_IN", length=10)
         w_out = builder.WaveformOut("W_OUT", length=10)
 
@@ -994,11 +1019,13 @@ class TestInvalidValues:
             initial_value=["123abc", "456def", "7890ghi"]
         )
 
+        # Test putting too many elements
         with pytest.raises(AssertionError):
             w_in.set(["1", "2", "3", "4"])
         with pytest.raises(AssertionError):
             w_out.set(["1", "2", "3", "4"])
 
+        # Test putting too long a string
         with pytest.raises(ValueError):
             w_in.set([VERY_LONG_STRING])
         with pytest.raises(ValueError):

--- a/tests/test_record_values.py
+++ b/tests/test_record_values.py
@@ -196,65 +196,43 @@ record_values_list = [
         "wIn_byte_string_array",
         builder.WaveformIn,
         [b"AB123", b"CD456", b"EF789"],
-        numpy.array(
-            ["AB123", "CD456", "EF789"], dtype=NUMPY_DTYPE_STRING
-        ),
-        numpy.ndarray,
+        ["AB123", "CD456", "EF789"],
+        list,
     ),
     (
         "wOut_byte_string_array",
         builder.WaveformOut,
         [b"12AB", b"34CD", b"56EF"],
-        numpy.array(
-            ["12AB", "34CD", "56EF"], dtype=NUMPY_DTYPE_STRING
-        ),
-        numpy.ndarray,
+        ["12AB", "34CD", "56EF"],
+        list,
     ),
     (
         "wIn_unicode_string_array",
         builder.WaveformIn,
         ["12€½", "34¾²", "56¹³"],
-        numpy.array(
-            [
-                b'12\xe2\x82\xac\xc2\xbd',
-                b'34\xc2\xbe\xc2\xb2',
-                b'56\xc2\xb9\xc2\xb3'
-            ],
-            dtype=NUMPY_DTYPE_STRING
-        ),
-        numpy.ndarray,
+        ["12€½", "34¾²", "56¹³"],
+        list,
     ),
     (
         "wOut_unicode_string_array",
         builder.WaveformOut,
         ["12€½", "34¾²", "56¹³"],
-        numpy.array(
-            [
-                b'12\xe2\x82\xac\xc2\xbd',
-                b'34\xc2\xbe\xc2\xb2',
-                b'56\xc2\xb9\xc2\xb3'
-            ],
-            dtype=NUMPY_DTYPE_STRING
-        ),
-        numpy.ndarray,
+        ["12€½", "34¾²", "56¹³"],
+        list,
     ),
     (
         "wIn_string_array",
         builder.WaveformIn,
         ["123abc", "456def", "7890ghi"],
-        numpy.array(
-            ["123abc", "456def", "7890ghi"], dtype=NUMPY_DTYPE_STRING
-        ),
-        numpy.ndarray,
+        ["123abc", "456def", "7890ghi"],
+        list,
     ),
     (
         "wOut_string_array",
         builder.WaveformOut,
         ["123abc", "456def", "7890ghi"],
-        numpy.array(
-            ["123abc", "456def", "7890ghi"],  dtype=NUMPY_DTYPE_STRING
-        ),
-        numpy.ndarray,
+        ["123abc", "456def", "7890ghi"],
+        list,
     ),
     (
         "longStringIn_str",
@@ -553,7 +531,7 @@ def run_test_function(
 
                 if (
                     creation_func in [builder.WaveformOut, builder.WaveformIn]
-                    and expected_value.dtype
+                    and hasattr(expected_value, 'dtype')
                     and expected_value.dtype in [numpy.float64, numpy.int32]
                 ):
                     log(
@@ -562,19 +540,11 @@ def run_test_function(
                         "scalar. Therefore we skip this check.")
                     continue
 
-                # caget on a waveform of strings will return unicode. Have to
-                # convert it manually to binary.
+                # caget on a waveform of strings will return a numpy array.
+                # Must extract it out to a list to match .get()
                 if isinstance(rec_val, numpy.ndarray) and len(rec_val) > 1 \
                         and rec_val.dtype.char in ["S", "U"]:
-                    result = numpy.empty(len(rec_val), NUMPY_DTYPE_STRING)
-                    for n, s in enumerate(rec_val):
-                        if isinstance(s, str):
-                            result[n] = s.encode('UTF-8', errors= 'ignore')
-                        else:
-                            result[n] = s
-                    rec_val = result
-                    # caget won't retrieve the full length 40 buffer
-                    rec_val = rec_val.astype(NUMPY_DTYPE_STRING)
+                    rec_val = [s for s in rec_val]
 
             record_value_asserts(
                 creation_func, rec_val, expected_value, expected_type

--- a/tests/test_record_values.py
+++ b/tests/test_record_values.py
@@ -208,6 +208,24 @@ record_values_list = [
         numpy.ndarray,
     ),
     (
+        "wIn_string_array",
+        builder.WaveformIn,
+        ["123", "456", "7890"],
+        numpy.array(
+            [b"123", b"456", b"7890"], dtype=numpy.dtype("|S40")
+        ),
+        numpy.ndarray,
+    ),
+    (
+        "wOut_string_array",
+        builder.WaveformOut,
+        ["123", "456", "7890"],
+        numpy.array(
+            [b"123", b"456", b"7890"], dtype=numpy.dtype("|S40")
+        ),
+        numpy.ndarray,
+    ),
+    (
         "longStringIn_str",
         builder.longStringIn,
         "ABC",

--- a/tests/test_record_values.py
+++ b/tests/test_record_values.py
@@ -190,6 +190,24 @@ record_values_list = [
         numpy.ndarray,
     ),
     (
+        "wIn_byte_string_array",
+        builder.WaveformIn,
+        [b"AB", b"CD", b"EF"],
+        numpy.array(
+            [b"AB", b"CD", b"EF"], dtype=numpy.dtype("|S40")
+        ),
+        numpy.ndarray,
+    ),
+    (
+        "wOut_byte_string_array",
+        builder.WaveformOut,
+        [b"AB", b"CD", b"EF"],
+        numpy.array(
+            [b"AB", b"CD", b"EF"], dtype=numpy.dtype("|S40")
+        ),
+        numpy.ndarray,
+    ),
+    (
         "longStringIn_str",
         builder.longStringIn,
         "ABC",


### PR DESCRIPTION
Allow creation records like:
```
t1 = builder.WaveformOut(
    "TEST1",  initial_value=["ZERO", "ONE", "MANY"]
)
t2 = builder.WaveformOut(
    "TEST2",  initial_value=[b"ZERO", b"ONE", b"MANY"]
)
```

Where each element of the array is treated as an EPICS string

Values returned will always be Python string lists:

```
> t1.get()
["ZERO", "ONE", "MANY"]
> t2.get()
["ZERO", "ONE", "MANY"]
```

(valid) Unicode characters may also be passed in, and will be returned as-is. Note that it is not always obvious how many Unicode characters can be safely entered into EPICS's 40 character string limits.