### PR TITLE
Allow "status" and "severity" on In record init

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Versioning <https://semver.org/spec/v2.0.0.html>`_.
 Unreleased_
 -----------
 
+- `Allow "status" and "severity" on In record init <../../pull/111>`_
+
 4.1.0_ - 2022-08-05
 -------------------
 

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -165,6 +165,19 @@ Test Facilities`_ documentation for more details of each function.
 
     This is used to specify an initial value for each record.
 
+    .. _status and severity:
+
+    `status and severity`
+    ~~~~~~~~~~~~~~~~~~~~~
+
+    Only available on IN records. These can be used with the alarm value enums
+    from `softioc.alarm` to set the initial alarm state of a record.
+
+    .. note::
+
+        By default the builder module sets ``PINI`` to ``YES``, which means the
+        record will process at initialization and the alarm status will be reset.
+
     .. _on_update:
 
     `on_update`
@@ -242,8 +255,6 @@ Test Facilities`_ documentation for more details of each function.
 
     .. seealso::
         `SetBlocking` for configuring a global default blocking value
-
-
 
 For all of these functions any EPICS database field can be assigned a value by
 passing it as a keyword argument for the corresponding field name (in upper

--- a/softioc/builder.py
+++ b/softioc/builder.py
@@ -1,5 +1,6 @@
 import os
 import numpy
+
 from .softioc import dbLoadDatabase
 
 from epicsdbbuilder import *
@@ -24,9 +25,16 @@ def _set_in_defaults(fields):
     fields.setdefault('SCAN', 'I/O Intr')
     fields.setdefault('PINI', 'YES')
     fields.setdefault('DISP', 1)
+    _set_alarm(fields)
 
 def _set_out_defaults(fields):
     fields.setdefault('OMSL', 'supervisory')
+
+def _set_alarm(fields):
+    if "status" in fields:
+        fields['STAT'] = _statStrings[fields.pop('status')]
+    if "severity" in fields:
+        fields['SEVR'] = _severityStrings[fields.pop('severity')]
 
 # For longout and ao we want DRV{L,H} to match {L,H}OPR by default
 def _set_scalar_out_defaults(fields, DRVL, DRVH):
@@ -75,6 +83,11 @@ _mbbPrefixes = [
 
 # All the severity strings supported by <prefix>SV
 _severityStrings = ['NO_ALARM', 'MINOR', 'MAJOR', 'INVALID']
+
+_statStrings = [
+    'NO_ALARM', 'READ', 'WRITE', 'HIHI', 'HIGH', 'LOLO', 'LOW', 'STATE', 'COS',
+    'COMM',  'TIMEOUT', 'HWLIMIT', 'CALC', 'SCAN', 'LINK', 'SOFT', 'BAD_SUB',
+    'UDF', 'DISABLE',  'SIMM', 'READ_ACCESS', 'WRITE_ACCESS']
 
 # Converts a list of (option [,severity]) values or tuples into field settings
 # suitable for mbbi and mbbo records.


### PR DESCRIPTION
This PR allows users to specify `severity` and `status` on the command line, with values from the `softioc.alarm` module. 

Closes #57 