### PR TITLE
Remove DeprecationWarning from using "+" operator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Added:
 - `Add Channel Access Report functions <../../pull/115>`_
 - Add ``WaveformIn`` to default exports from ``softioc.builder``
 
+Fixed:
+
+- `Fix DeprecationWarning from numpy when using "+" <../../pull/123>`_
+
 4.2.0_ - 2022-11-08
 -------------------
 

--- a/softioc/device.py
+++ b/softioc/device.py
@@ -409,7 +409,7 @@ class WaveformBase(ProcessDeviceSupportCore):
         # common class of bug, at the cost of duplicated code and data, here we
         # ensure a copy is taken of the value.
         assert len(value) <= self._nelm, 'Value too long for waveform'
-        return +value
+        return numpy.copy(value)
 
     def _epics_to_value(self, value):
         return value

--- a/softioc/fields.py
+++ b/softioc/fields.py
@@ -147,4 +147,4 @@ class _Record(object):
 
 
 
-__all__ = ['RecordFactory', 'DbfCodeToNumpy', 'ca_timestamp']
+__all__ = ['RecordFactory', 'ca_timestamp']


### PR DESCRIPTION
This used to be an easy way to return a copy of the array. Now we must use the explicit copy function.

Also removing an export for an enum that no longer exists.