### PR TITLE
Improve string representation of RecordWrapper

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Versioning <https://semver.org/spec/v2.0.0.html>`_.
 Unreleased_
 -----------
 
+Changed:
+
+- `Improve string representation of RecordWrapper instances <../../pull/130>`
+
 4.3.0_ - 2023-04-04
 -------------------
 

--- a/softioc/pythonSoftIoc.py
+++ b/softioc/pythonSoftIoc.py
@@ -80,8 +80,7 @@ class RecordWrapper(object):
         return self.__builder(*specifiers)
 
     def __str__(self):
-        return str(self.__builder)
-
+        return self.__device._name
 
 
 class PythonDevice(object):


### PR DESCRIPTION
The returned string is the full DeviceName:RecordName.

Previously the string representation would be lost when builder.LoadDatabase() is called, as the __builder instance is removed and so __str__ returns None.

The __device is not removed at any point, and so can always be safely used to fetch the full name.