### PR TITLE
Use pvxslibs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,6 @@ ext = Extension(
         devIocStats_src, devIocStats_os, devIocStats_default
     ],
     dsos = [
-        'epicscorelibs.lib.qsrv',
-        'epicscorelibs.lib.pvAccessIOC',
-        'epicscorelibs.lib.pvAccess',
-        'epicscorelibs.lib.pvData',
         'epicscorelibs.lib.dbRecStd',
         'epicscorelibs.lib.dbCore',
         'epicscorelibs.lib.ca',
@@ -95,6 +91,8 @@ setup(
     install_requires = [
         # Dependency version declared in pyproject.toml
         epicscorelibs.version.abi_requires(),
+        "pvxslibs>=1.2.1a1",
+        "setuptools_dso>=2.4",
         "numpy",
         "epicsdbbuilder>=1.4"
     ],

--- a/softioc/__init__.py
+++ b/softioc/__init__.py
@@ -1,10 +1,6 @@
 '''Python soft IOC module.'''
 import os
 
-from epicscorelibs import path
-from epicscorelibs.ioc import \
-    iocshRegisterCommon, registerRecordDeviceDriver, pdbbase
-
 # Do this as early as possible, in case we happen to use cothread
 # This will set the CATOOLS_LIBCA_PATH environment variable in case we use
 # cothread.catools. It works even if we don't have cothread installed
@@ -12,17 +8,44 @@ import epicscorelibs.path.cothread  # noqa
 
 # This import will also pull in the extension, which is needed
 # before we call iocshRegisterCommon
-from .imports import dbLoadDatabase
 from ._version_git import __version__
+from .imports import dbLoadDatabase
 
-# Need to do this before calling anything in device.py
-iocshRegisterCommon()
-for dbd in ('base.dbd', 'PVAServerRegister.dbd', 'qsrv.dbd'):
-    dbLoadDatabase(dbd, os.path.join(path.base_path, 'dbd'), None)
-iocStats = os.path.join(os.path.dirname(__file__), "iocStats", "devIocStats")
-dbLoadDatabase('devIocStats.dbd', iocStats, None)
+def load_dbd():
+    import ctypes
+    from epicscorelibs import path
+    from epicscorelibs.ioc import \
+        iocshRegisterCommon, registerRecordDeviceDriver, pdbbase
+    import pvxslibs.path
+    from setuptools_dso.runtime import find_dso
 
-if registerRecordDeviceDriver(pdbbase):
-    raise RuntimeError('Error registering')
+    dbd_paths = ':'.join([
+        os.path.join(path.base_path, 'dbd'),
+        pvxslibs.path.dbd_path,
+        os.path.join(os.path.dirname(__file__), "iocStats", "devIocStats"),
+    ])
+    dbds = [
+        'base.dbd', # must be first
+        'devIocStats.dbd',
+        'pvxsIoc.dbd',
+    ]
+
+    # Need to do this before calling anything in device.py
+    iocshRegisterCommon()
+    for dbd in dbds:
+        dbLoadDatabase(dbd, dbd_paths, None)
+
+    from ._extension import install_pv_logging
+    dbRecStd = ctypes.CDLL(find_dso('epicscorelibs.lib.dbRecStd'), ctypes.RTLD_GLOBAL)
+    pvxsIoc = ctypes.CDLL(find_dso('pvxslibs.lib.pvxsIoc'), ctypes.RTLD_GLOBAL)
+
+    # must explicitly enable QSRV while "Feature Preview"
+    os.environ.setdefault('PVXS_QSRV_ENABLE', 'YES')
+
+    if registerRecordDeviceDriver(pdbbase):
+        raise RuntimeError('Error registering')
+
+load_dbd()
+del load_dbd
 
 __all__ = ['__version__']


### PR DESCRIPTION
My attempt to switch from pva2pva to pvxs.  Also adds a way to execute any IOC shell command.  Needs pvxslibs 1.2.1a1, specifically https://github.com/mdavidsaver/pvxs/commit/a1eb49386f3b3e7c8a3884413275e32e7ac58402 .

```
$ python3 -m softioc ../docs/examples/example_asyncio_ioc.py
INFO: PVXS QSRV2 is loaded and ENABLED.
Starting iocInit
############################################################################
## EPICS 7.0.7.0
## Rev. 7.0.7.99.0.0a1
## Rev. Date 7.0.7.99.0.0a1
############################################################################
iocRun: All initialization complete
Python 3.9.2 (default, Feb 28 2021, 17:03:44) 
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> iocsh.epicsThreadShowAll()
            NAME       EPICS ID   LWP ID   OSIPRI  OSSPRI  STATE
          _main_      0x26f06b0        6      0       0       OK
          PVXTCP      0x2b9c570        9     18       0       OK
          PVXUDP      0x2badac0       10     16       0       OK
...
```