### PR TITLE
Add a non-interactive function to use softioc in deamon mode 

### DIFF
--- a/softioc/asyncio_dispatcher.py
+++ b/softioc/asyncio_dispatcher.py
@@ -3,6 +3,7 @@ import inspect
 import logging
 import threading
 import atexit
+import signal
 
 class AsyncioDispatcher:
     def __init__(self, loop=None):
@@ -31,6 +32,23 @@ class AsyncioDispatcher:
             raise ValueError("Provided asyncio event loop is not running")
         else:
             self.loop = loop
+
+    def wait_for_quit(self):
+
+        stop_event = threading.Event()
+
+        # Signal end of loop
+        async def stop_loop():
+            stop_event.set()
+
+        def signal_exit():
+            asyncio.run_coroutine_threadsafe(stop_loop(), self.loop)
+
+        # Configure signal handlers to call signal_exit
+        for sig in ('SIGINT', 'SIGTERM'):
+            self.loop.add_signal_handler(getattr(signal, sig), signal_exit)
+
+        stop_event.wait()
 
     def __call__(
             self,

--- a/softioc/cothread_dispatcher.py
+++ b/softioc/cothread_dispatcher.py
@@ -19,6 +19,11 @@ class CothreadDispatcher:
         else:
             self.__dispatcher = dispatcher
 
+        def wait_for_quit():
+            cothread.WaitForQuit()
+
+        self.wait_for_quit = wait_for_quit
+
     def __call__(
             self,
             func,

--- a/softioc/softioc.py
+++ b/softioc/softioc.py
@@ -352,3 +352,17 @@ def interactive_ioc(context = {}, call_exit = True):
 
     if call_exit:
         safeEpicsExit(0)
+
+def non_interactive_ioc():
+    '''Launches IOC in non-interactive mode for background use
+
+    When used with a service manager, use python's -u option or the environment
+    variable PYTHONUNBUFFERED=TRUE.
+    This ensures that python output, i.e. stdoute and stderr streams, is sent
+    directly to the terminal.
+    '''
+    if device.dispatcher:
+        device.dispatcher.wait_for_quit()
+        safeEpicsExit(0)
+    else:
+        print("No dispatcher found")


### PR DESCRIPTION
I propose adding the `non_interactive_ioc` function to allow the use of softioc in daemon mode. This mode can, for example, be used with systemd. It is compatible with `asyncio` and `cothread`.

To ensure that information is correctly logged in the journal, it is recommended to execute the Python script with the `-u` option or to set the environment variable `PYTHONUNBUFFERED=TRUE`.

Here is an example of a service:
```
[Unit]
Description=IOC
After=network.target

[Service]
User=root
Group=root
WorkingDirectory=/opt
ExecStart=/opt/softioc/bin/python -u /opt/example.py
Environment="PATH=/opt/softioc/bin"
Restart=always

[Install]
WantedBy=multi-user.target
```

And an example of a script:

```
# Import the basic framework components.
from softioc import softioc, builder
import cothread

# Set the record prefix
builder.SetDeviceName("MY-DEVICE-PREFIX")

# Create some records
ai = builder.aIn('AI', initial_value=5)
ao = builder.aOut('AO', initial_value=12.45, on_update=lambda v: ai.set(v))

# Boilerplate to get the IOC started
builder.LoadDatabase()
softioc.iocInit()

# Start processes required to be run after iocInit
def update():
    while True:
        ai.set(ai.get() + 1)
        print(ai.get())
        cothread.Sleep(1)

cothread.Spawn(update)

if __name__ == "__main__":
    softioc.non_interactive_ioc()
```
