### PR TITLE
Add a non-interactive function to use softioc in deamon mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Versioning <https://semver.org/spec/v2.0.0.html>`_.
 Unreleased_
 -----------
 
+Removed:
+
+- `Remove python3.6 support <../../pull/138>`_
+
 Changed:
 
 - `AsyncioDispatcher cleanup tasks atexit <../../pull/138>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,9 @@ Unreleased_
 -----------
 
 Added:
+
 - `Enable setting alarm status of Out records <../../pull/157>`_
+- `Adding the non_interactive_ioc function <../../pull/156>`_
 
 Removed:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ Versioning <https://semver.org/spec/v2.0.0.html>`_.
 Unreleased_
 -----------
 
+Added:
+- `Enable setting alarm status of Out records <../../pull/157>`_
+
 Removed:
 
 - `Remove python3.6 support <../../pull/138>`_

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -454,9 +454,10 @@ starting the IOC.
     Alarm Value Definitions: `softioc.alarm`
     ----------------------------------------
 
-
 The following values can be passed to IN record :meth:`~softioc.device.ProcessDeviceSupportIn.set` and
-:meth:`~softioc.device.ProcessDeviceSupportIn.set_alarm` methods.
+:meth:`~softioc.device.ProcessDeviceSupportIn.set_alarm` methods, and to OUT record
+:meth:`~softioc.device.ProcessDeviceSupportOut.set` and
+:meth:`~softioc.device.ProcessDeviceSupportOut.set_alarm`.
 
 ..  attribute::
         NO_ALARM = 0
@@ -608,13 +609,21 @@ Working with OUT records
     ``ao``, ``bo``, ``longout``, ``mbbo`` and OUT ``waveform`` records.  All OUT
     records support the following methods.
 
-    ..  method:: set(value, process=True)
+    ..  method:: set(value, process=True, severity=NO_ALARM, alarm=UDF_ALARM)
 
-        Updates the value associated with the record.  By default this will
+        Updates the stored value and severity status.  By default this will
         trigger record processing, and so will cause any associated `on_update`
         and `validate` methods to be called.  If ``process`` is `False`
         then neither of these methods will be called, but the value will still
         be updated.
+
+    ..  method:: set_alarm(severity, alarm)
+
+        This is exactly equivalent to calling::
+
+            rec.set(rec.get(), severity=severity, alarm=alarm)
+
+        and triggers an alarm status change without changing the value.
 
     ..  method:: get()
 

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -120,6 +120,12 @@ Test Facilities`_ documentation for more details of each function.
 ..  autofunction:: generalTimeReport
 ..  autofunction:: eltc
 
+.. autofunction:: non_interactive_ioc
+
+When used with a service manager, use python's -u option or the environment
+variable PYTHONUNBUFFERED=TRUE. This ensures that python output, i.e. stdout
+and stderr streams, is sent directly to the terminal.
+
 ..  attribute:: exit
 
     Displaying this value will invoke ``epicsExit()`` causing the IOC to

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -550,7 +550,7 @@ class which provides the methods documented below.
     This class is used to implement Python device support for the record types
     ``ai``, ``bi``, ``longin``, ``mbbi`` and IN ``waveform`` records.
 
-    ..  method:: set(value, severity=NO_ALARM, alarm=UDF_ALARM, timestamp=None)
+    ..  method:: set(value, severity=NO_ALARM, alarm=NO_ALARM, timestamp=None)
 
         Updates the stored value and severity status and triggers an update.  If
         ``SCAN`` has been set to ``'I/O Intr'`` (which is the default if the
@@ -609,7 +609,7 @@ Working with OUT records
     ``ao``, ``bo``, ``longout``, ``mbbo`` and OUT ``waveform`` records.  All OUT
     records support the following methods.
 
-    ..  method:: set(value, process=True, severity=NO_ALARM, alarm=UDF_ALARM)
+    ..  method:: set(value, process=True, severity=NO_ALARM, alarm=NO_ALARM)
 
         Updates the stored value and severity status.  By default this will
         trigger record processing, and so will cause any associated `on_update`

--- a/softioc/alarm.py
+++ b/softioc/alarm.py
@@ -5,6 +5,7 @@ MAJOR_ALARM = 2
 INVALID_ALARM = 3
 
 # Some alarm code definitions taken from EPICS alarm.h
+# NO_ALARM = 0
 READ_ALARM = 1
 WRITE_ALARM = 2
 HIHI_ALARM = 3

--- a/softioc/asyncio_dispatcher.py
+++ b/softioc/asyncio_dispatcher.py
@@ -50,20 +50,13 @@ class AsyncioDispatcher:
         self.__shutdown()
     
     def wait_for_quit(self):
-        async_stop_event = asyncio.Event()
         stop_event = threading.Event()
 
-        def signal_exit():
-            self.loop.call_soon_threadsafe(async_stop_event.set)
-        
-        async def async_signal_exit():
-            await async_stop_event.wait()
+        def signal_handler(signum, frame):
             stop_event.set()
 
-        for sig in (signal.SIGINT, signal.SIGTERM):
-            signal.signal(sig, lambda signum, frame: signal_exit())
-            
-        asyncio.run_coroutine_threadsafe(async_signal_exit(), self.loop)
+        signal.signal(signal.SIGINT, signal_handler)
+        signal.signal(signal.SIGTERM, signal_handler)
 
         stop_event.wait()
 

--- a/softioc/asyncio_dispatcher.py
+++ b/softioc/asyncio_dispatcher.py
@@ -50,7 +50,6 @@ class AsyncioDispatcher:
         self.__shutdown()
     
     def wait_for_quit(self):
-
         async_stop_event = asyncio.Event()
         stop_event = threading.Event()
 
@@ -61,9 +60,9 @@ class AsyncioDispatcher:
             await async_stop_event.wait()
             stop_event.set()
 
-        for sig in ('SIGINT', 'SIGTERM'):
-            signal.signal(getattr(signal, sig), lambda signum, frame: signal_exit())
-
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            signal.signal(sig, lambda signum, frame: signal_exit())
+            
         asyncio.run_coroutine_threadsafe(async_signal_exit(), self.loop)
 
         stop_event.wait()

--- a/softioc/cothread_dispatcher.py
+++ b/softioc/cothread_dispatcher.py
@@ -19,6 +19,11 @@ class CothreadDispatcher:
         else:
             self.__dispatcher = dispatcher
 
+        def wait_for_quit():
+            cothread.WaitForQuit()
+
+        self.wait_for_quit = wait_for_quit
+
     def __call__(
             self,
             func,

--- a/softioc/cothread_dispatcher.py
+++ b/softioc/cothread_dispatcher.py
@@ -19,10 +19,7 @@ class CothreadDispatcher:
         else:
             self.__dispatcher = dispatcher
 
-        def wait_for_quit():
-            cothread.WaitForQuit()
-
-        self.wait_for_quit = wait_for_quit
+        self.wait_for_quit = cothread.WaitForQuit
 
     def __call__(
             self,

--- a/softioc/device.py
+++ b/softioc/device.py
@@ -137,7 +137,7 @@ class ProcessDeviceSupportIn(ProcessDeviceSupportCore):
         return self._epics_rc_
 
     def set(self, value,
-            severity=alarm.NO_ALARM, alarm=alarm.UDF_ALARM, timestamp=None):
+            severity=alarm.NO_ALARM, alarm=alarm.NO_ALARM, timestamp=None):
         '''Updates the stored value and triggers an update.  The alarm
         severity and timestamp can also be specified if appropriate.'''
         value = self._value_to_epics(value)
@@ -177,14 +177,16 @@ class ProcessDeviceSupportOut(ProcessDeviceSupportCore):
 
         if 'initial_value' in kargs:
             value = self._value_to_epics(kargs.pop('initial_value'))
-            initial_alarm = alarm.NO_ALARM
+            initial_severity = alarm.NO_ALARM
+            initial_status = alarm.NO_ALARM
         else:
             value = None
             # To maintain backwards compatibility, if there is no initial value
             # we mark the record as invalid
-            initial_alarm = alarm.INVALID_ALARM
+            initial_severity = alarm.INVALID_ALARM
+            initial_status = alarm.UDF_ALARM
 
-        self._value = (value, initial_alarm, alarm.UDF_ALARM)
+        self._value = (value, initial_severity, initial_status)
 
         self._blocking = kargs.pop('blocking', blocking)
         if self._blocking:
@@ -274,7 +276,7 @@ class ProcessDeviceSupportOut(ProcessDeviceSupportCore):
 
 
     def set(self, value, process=True,
-            severity=alarm.NO_ALARM, alarm=alarm.UDF_ALARM):
+            severity=alarm.NO_ALARM, alarm=alarm.NO_ALARM):
         '''Special routine to set the value directly.'''
         value = self._value_to_epics(value)
         try:

--- a/softioc/device.py
+++ b/softioc/device.py
@@ -223,12 +223,11 @@ class ProcessDeviceSupportOut(ProcessDeviceSupportCore):
         if record.PACT:
             return EPICS_OK
 
-        # Ignore memoized value, retrieve it from the VAL field directly later
+        # Ignore memoized value, retrieve it from the VAL field instead
+        value = self._read_value(record)
         _, severity, alarm = self._value
-
         self.process_severity(record, severity, alarm)
 
-        value = self._read_value(record)
         if not self.__always_update and \
                 self._compare_values(value, self._value[0]):
             # If the value isn't making a change then don't do anything.
@@ -288,12 +287,7 @@ class ProcessDeviceSupportOut(ProcessDeviceSupportCore):
             self.__enable_write = True
 
     def get(self):
-        if self._value[0] is None:
-            # Before startup complete if no value set return default value
-            value = self._default_value()
-        else:
-            value = self._value[0]
-        return self._epics_to_value(value)
+        return self._epics_to_value(self._value[0])
 
 
 def _Device(Base, record_type, ctype, dbf_type, epics_rc, mlst = False):

--- a/softioc/device.py
+++ b/softioc/device.py
@@ -180,7 +180,7 @@ class ProcessDeviceSupportOut(ProcessDeviceSupportCore):
             initial_severity = alarm.NO_ALARM
             initial_status = alarm.NO_ALARM
         else:
-            value = None
+            value = self._default_value()
             # To maintain backwards compatibility, if there is no initial value
             # we mark the record as invalid
             initial_severity = alarm.INVALID_ALARM
@@ -198,11 +198,6 @@ class ProcessDeviceSupportOut(ProcessDeviceSupportCore):
         '''Special record initialisation for out records only: implements
         special record initialisation if an initial value has been specified,
         allowing out records to have a sensible initial value.'''
-        if self._value[0] is None:
-            # Cannot set in __init__ (like we do for In records), as we want
-            # the record alarm status to be set if no value was provided
-            value = self._default_value()
-            self._value = (value, self._value[1], self._value[2])
 
         self._write_value(record, self._value[0])
         if 'MLST' in self._fields_:

--- a/softioc/softioc.py
+++ b/softioc/softioc.py
@@ -352,3 +352,17 @@ def interactive_ioc(context = {}, call_exit = True):
 
     if call_exit:
         safeEpicsExit(0)
+
+def non_interactive_ioc():
+    '''Launches IOC in non-interactive mode for background use
+
+    When used with a service manager, use python's -u option or the environment
+    variable PYTHONUNBUFFERED=TRUE.
+    This ensures that python output, i.e. stdoute and stderr streams, is sent
+    directly to the terminal.
+    '''
+    if device.dispatcher:
+        device.dispatcher.wait_for_quit()
+        safeEpicsExit(0)
+    else:
+        print("No dispatcher found")

--- a/softioc/softioc.py
+++ b/softioc/softioc.py
@@ -358,7 +358,7 @@ def non_interactive_ioc():
 
     When used with a service manager, use python's -u option or the environment
     variable PYTHONUNBUFFERED=TRUE.
-    This ensures that python output, i.e. stdoute and stderr streams, is sent
+    This ensures that python output, i.e. stdout and stderr streams, is sent
     directly to the terminal.
     '''
     if device.dispatcher:

--- a/softioc/softioc.py
+++ b/softioc/softioc.py
@@ -354,15 +354,10 @@ def interactive_ioc(context = {}, call_exit = True):
         safeEpicsExit(0)
 
 def non_interactive_ioc():
-    '''Launches IOC in non-interactive mode for background use
-
-    When used with a service manager, use python's -u option or the environment
-    variable PYTHONUNBUFFERED=TRUE.
-    This ensures that python output, i.e. stdout and stderr streams, is sent
-    directly to the terminal.
+    '''Function to run the IOC in non-interactive mode. This mode is useful for
+    running the IOC as a background process without user interaction.
+    This function expects a stop signal. When it receives one, the IOC stops.
     '''
-    if device.dispatcher:
-        device.dispatcher.wait_for_quit()
-        safeEpicsExit(0)
-    else:
-        print("No dispatcher found")
+    device.dispatcher.wait_for_quit()
+    safeEpicsExit(0)
+


### PR DESCRIPTION
I propose this modification, following the initial request #155

Reminder of the initial proposal: 

I propose adding the non_interactive_ioc function to allow the use of softioc in daemon mode. This mode can, for example, be used with systemd. It is compatible with asyncio and cothread.

To ensure that information is correctly logged in the journal, it is recommended to execute the Python script with the `-u` option or to set the environment variable `PYTHONUNBUFFERED=TRUE`.

Here is an example of a service:

```
[Unit]
Description=IOC
After=network.target

[Service]
User=root
Group=root
WorkingDirectory=/opt
ExecStart=/opt/softioc/bin/python -u /opt/example.py
Environment="PATH=/opt/softioc/bin"
Restart=always

[Install]
WantedBy=multi-user.target
```

And an example of a script:

```
# Import the basic framework components.
from softioc import softioc, builder
import cothread

# Set the record prefix
builder.SetDeviceName("MY-DEVICE-PREFIX")

# Create some records
ai = builder.aIn('AI', initial_value=5)
ao = builder.aOut('AO', initial_value=12.45, on_update=lambda v: ai.set(v))

# Boilerplate to get the IOC started
builder.LoadDatabase()
softioc.iocInit()

# Start processes required to be run after iocInit
def update():
    while True:
        ai.set(ai.get() + 1)
        print(ai.get())
        cothread.Sleep(1)

cothread.Spawn(update)

if __name__ == "__main__":
    softioc.non_interactive_ioc()
```

