### PR TITLE
Enable setting alarm status of Out records

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ Versioning <https://semver.org/spec/v2.0.0.html>`_.
 Unreleased_
 -----------
 
+Added:
+- `Enable setting alarm status of Out records <../../pull/157>`_
+
 Removed:
 
 - `Remove python3.6 support <../../pull/138>`_

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -454,9 +454,10 @@ starting the IOC.
     Alarm Value Definitions: `softioc.alarm`
     ----------------------------------------
 
-
 The following values can be passed to IN record :meth:`~softioc.device.ProcessDeviceSupportIn.set` and
-:meth:`~softioc.device.ProcessDeviceSupportIn.set_alarm` methods.
+:meth:`~softioc.device.ProcessDeviceSupportIn.set_alarm` methods, and to OUT record
+:meth:`~softioc.device.ProcessDeviceSupportOut.set` and
+:meth:`~softioc.device.ProcessDeviceSupportOut.set_alarm`.
 
 ..  attribute::
         NO_ALARM = 0
@@ -608,13 +609,21 @@ Working with OUT records
     ``ao``, ``bo``, ``longout``, ``mbbo`` and OUT ``waveform`` records.  All OUT
     records support the following methods.
 
-    ..  method:: set(value, process=True)
+    ..  method:: set(value, process=True, severity=NO_ALARM, alarm=UDF_ALARM)
 
-        Updates the value associated with the record.  By default this will
+        Updates the stored value and severity status.  By default this will
         trigger record processing, and so will cause any associated `on_update`
         and `validate` methods to be called.  If ``process`` is `False`
         then neither of these methods will be called, but the value will still
         be updated.
+
+    ..  method:: set_alarm(severity, alarm)
+
+        This is exactly equivalent to calling::
+
+            rec.set(rec.get(), severity=severity, alarm=alarm)
+
+        and triggers an alarm status change without changing the value.
 
     ..  method:: get()
 

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -550,7 +550,7 @@ class which provides the methods documented below.
     This class is used to implement Python device support for the record types
     ``ai``, ``bi``, ``longin``, ``mbbi`` and IN ``waveform`` records.
 
-    ..  method:: set(value, severity=NO_ALARM, alarm=UDF_ALARM, timestamp=None)
+    ..  method:: set(value, severity=NO_ALARM, alarm=NO_ALARM, timestamp=None)
 
         Updates the stored value and severity status and triggers an update.  If
         ``SCAN`` has been set to ``'I/O Intr'`` (which is the default if the
@@ -609,7 +609,7 @@ Working with OUT records
     ``ao``, ``bo``, ``longout``, ``mbbo`` and OUT ``waveform`` records.  All OUT
     records support the following methods.
 
-    ..  method:: set(value, process=True, severity=NO_ALARM, alarm=UDF_ALARM)
+    ..  method:: set(value, process=True, severity=NO_ALARM, alarm=NO_ALARM)
 
         Updates the stored value and severity status.  By default this will
         trigger record processing, and so will cause any associated `on_update`

--- a/softioc/alarm.py
+++ b/softioc/alarm.py
@@ -5,6 +5,7 @@ MAJOR_ALARM = 2
 INVALID_ALARM = 3
 
 # Some alarm code definitions taken from EPICS alarm.h
+# NO_ALARM = 0
 READ_ALARM = 1
 WRITE_ALARM = 2
 HIHI_ALARM = 3

--- a/softioc/device.py
+++ b/softioc/device.py
@@ -137,7 +137,7 @@ class ProcessDeviceSupportIn(ProcessDeviceSupportCore):
         return self._epics_rc_
 
     def set(self, value,
-            severity=alarm.NO_ALARM, alarm=alarm.UDF_ALARM, timestamp=None):
+            severity=alarm.NO_ALARM, alarm=alarm.NO_ALARM, timestamp=None):
         '''Updates the stored value and triggers an update.  The alarm
         severity and timestamp can also be specified if appropriate.'''
         value = self._value_to_epics(value)
@@ -177,14 +177,16 @@ class ProcessDeviceSupportOut(ProcessDeviceSupportCore):
 
         if 'initial_value' in kargs:
             value = self._value_to_epics(kargs.pop('initial_value'))
-            initial_alarm = alarm.NO_ALARM
+            initial_severity = alarm.NO_ALARM
+            initial_status = alarm.NO_ALARM
         else:
             value = None
             # To maintain backwards compatibility, if there is no initial value
             # we mark the record as invalid
-            initial_alarm = alarm.INVALID_ALARM
+            initial_severity = alarm.INVALID_ALARM
+            initial_status = alarm.UDF_ALARM
 
-        self._value = (value, initial_alarm, alarm.UDF_ALARM)
+        self._value = (value, initial_severity, initial_status)
 
         self._blocking = kargs.pop('blocking', blocking)
         if self._blocking:
@@ -274,7 +276,7 @@ class ProcessDeviceSupportOut(ProcessDeviceSupportCore):
 
 
     def set(self, value, process=True,
-            severity=alarm.NO_ALARM, alarm=alarm.UDF_ALARM):
+            severity=alarm.NO_ALARM, alarm=alarm.NO_ALARM):
         '''Special routine to set the value directly.'''
         value = self._value_to_epics(value)
         try:

--- a/softioc/device.py
+++ b/softioc/device.py
@@ -223,12 +223,11 @@ class ProcessDeviceSupportOut(ProcessDeviceSupportCore):
         if record.PACT:
             return EPICS_OK
 
-        # Ignore memoized value, retrieve it from the VAL field directly later
+        # Ignore memoized value, retrieve it from the VAL field instead
+        value = self._read_value(record)
         _, severity, alarm = self._value
-
         self.process_severity(record, severity, alarm)
 
-        value = self._read_value(record)
         if not self.__always_update and \
                 self._compare_values(value, self._value[0]):
             # If the value isn't making a change then don't do anything.
@@ -288,12 +287,7 @@ class ProcessDeviceSupportOut(ProcessDeviceSupportCore):
             self.__enable_write = True
 
     def get(self):
-        if self._value[0] is None:
-            # Before startup complete if no value set return default value
-            value = self._default_value()
-        else:
-            value = self._value[0]
-        return self._epics_to_value(value)
+        return self._epics_to_value(self._value[0])
 
 
 def _Device(Base, record_type, ctype, dbf_type, epics_rc, mlst = False):

--- a/softioc/device.py
+++ b/softioc/device.py
@@ -180,7 +180,7 @@ class ProcessDeviceSupportOut(ProcessDeviceSupportCore):
             initial_severity = alarm.NO_ALARM
             initial_status = alarm.NO_ALARM
         else:
-            value = None
+            value = self._default_value()
             # To maintain backwards compatibility, if there is no initial value
             # we mark the record as invalid
             initial_severity = alarm.INVALID_ALARM
@@ -198,11 +198,6 @@ class ProcessDeviceSupportOut(ProcessDeviceSupportCore):
         '''Special record initialisation for out records only: implements
         special record initialisation if an initial value has been specified,
         allowing out records to have a sensible initial value.'''
-        if self._value[0] is None:
-            # Cannot set in __init__ (like we do for In records), as we want
-            # the record alarm status to be set if no value was provided
-            value = self._default_value()
-            self._value = (value, self._value[1], self._value[2])
 
         self._write_value(record, self._value[0])
         if 'MLST' in self._fields_:


### PR DESCRIPTION
Adds the `set_alarm` method to `ProcessDeviceSupportOut`, along with extra keyword arguments to `set`. As these are keyword args with defaults, there should be no compatibility problems.

Tests added to check calling `set_alarm()` before or after IocInit() causes the severity and status attributes to be set as expected.

Closes #53.