### PR TITLE
Add int64in/out record support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased_
 
 Added:
 
+- `Add int64In/Out record support <../../pull/161>`_
 - `Enable setting alarm status of Out records <../../pull/157>`_
 - `Adding the non_interactive_ioc function <../../pull/156>`_
 

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -155,7 +155,7 @@ and stderr streams, is sent directly to the terminal.
     but note that only the following records types have direct support from this
     module:
 
-        ai, ao, bi, bo, longin, longout, mbbi, mbbo, stringin, stringout, waveform
+        ai, ao, bi, bo, int64in, int64out, longin, longout, mbbi, mbbo, stringin, stringout, waveform
 
     The following methods create records of the corresponding type.  For all records
     the `initial_value` parameter can be used to specify an initial value for the
@@ -284,6 +284,15 @@ All functions return a wrapped `ProcessDeviceSupportIn` or
 
     Create ``bi`` and ``bo`` records with the specified names for false (zero)
     and true (one).
+
+..  function::
+        int64In(name, LOPR=None, HOPR=None, EGU=None, **fields)
+        int64Out(name, DRVL=None, DRVH=None, EGU=None, **fields)
+
+    Create ``int64In`` and ``int64Out`` records with specified limits and units.
+    The lower and upper display limits for the record can be specified.  For
+    ``int64Out`` records the ``LOPR`` and ``HOPR`` fields will be set by default
+    to the values of the ``DRVL`` and ``DRVH`` fields respectively.
 
 ..  function::
         longIn(name, LOPR=None, HOPR=None, EGU=None, **fields)
@@ -532,15 +541,17 @@ Create IN records (used for publishing data *from* the IOC, the naming of the
 direction is confusing) using the following `softioc.builder` methods:
 
     :func:`~softioc.builder.aIn`, :func:`~softioc.builder.boolIn`,
-    :func:`~softioc.builder.longIn`, :func:`~softioc.builder.stringIn`,
-    :func:`~softioc.builder.mbbIn`, :func:`~softioc.builder.WaveformIn`.
+    :func:`~softioc.builder.int64In` :func:`~softioc.builder.longIn`,
+    :func:`~softioc.builder.stringIn`, :func:`~softioc.builder.mbbIn`,
+    :func:`~softioc.builder.WaveformIn`.
 
 Create OUT records for receiving control information into the IOC using the
 following methods:
 
     :func:`~softioc.builder.aOut`, :func:`~softioc.builder.boolOut`,
-    :func:`~softioc.builder.longOut`, :func:`~softioc.builder.stringOut`,
-    :func:`~softioc.builder.mbbOut`, :func:`~softioc.builder.WaveformOut`.
+    :func:`~softioc.builder.int64Out`, :func:`~softioc.builder.longOut`,
+    :func:`~softioc.builder.stringOut`, :func:`~softioc.builder.mbbOut`,
+    :func:`~softioc.builder.WaveformOut`.
 
 For all records the `initial_value` keyword argument can be used to specify the
 records value on startup.
@@ -554,7 +565,7 @@ class which provides the methods documented below.
 ..  class:: ProcessDeviceSupportIn
 
     This class is used to implement Python device support for the record types
-    ``ai``, ``bi``, ``longin``, ``mbbi`` and IN ``waveform`` records.
+    ``ai``, ``bi``, ``int64in``, ``longin``, ``mbbi`` and IN ``waveform`` records.
 
     ..  method:: set(value, severity=NO_ALARM, alarm=NO_ALARM, timestamp=None)
 

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -623,7 +623,7 @@ Working with OUT records
 ..  class:: ProcessDeviceSupportOut
 
     This class is used to implement Python device support for the record types
-    ``ao``, ``bo``, ``longout``, ``mbbo`` and OUT ``waveform`` records.  All OUT
+    ``ao``, ``bo``, ``int64out``, ``longout``, ``mbbo`` and OUT ``waveform`` records.  All OUT
     records support the following methods.
 
     ..  method:: set(value, process=True, severity=NO_ALARM, alarm=NO_ALARM)

--- a/softioc/builder.py
+++ b/softioc/builder.py
@@ -78,6 +78,17 @@ def longOut(name, DRVL=None, DRVH=None, EGU=None, **fields):
     _set_scalar_out_defaults(fields, DRVL, DRVH)
     return PythonDevice.longout(name, EGU = EGU, **fields)
 
+def int64In(name, LOPR=None, HOPR=None, EGU=None, **fields):
+    _set_in_defaults(fields)
+    fields.setdefault('MDEL', -1)
+    return PythonDevice.int64in(
+        name, LOPR = LOPR, HOPR = HOPR, EGU = EGU, **fields)
+
+def int64Out(name, DRVL=None, DRVH=None, EGU=None, **fields):
+    _set_out_defaults(fields)
+    _set_scalar_out_defaults(fields, DRVL, DRVH)
+    return PythonDevice.int64out(name, EGU = EGU, **fields)
+
 
 # Field name prefixes for mbbi/mbbo records.
 _mbbPrefixes = [

--- a/softioc/device.dbd
+++ b/softioc/device.dbd
@@ -1,5 +1,7 @@
 device(longin,    INST_IO, devPython_longin,    "Python")
 device(longout,   INST_IO, devPython_longout,   "Python")
+device(int64in,   INST_IO, devPython_int64in,   "Python")
+device(int64out,  INST_IO, devPython_int64out,  "Python")
 device(ai,        INST_IO, devPython_ai,        "Python")
 device(ao,        INST_IO, devPython_ao,        "Python")
 device(bi,        INST_IO, devPython_bi,        "Python")

--- a/softioc/device.py
+++ b/softioc/device.py
@@ -316,6 +316,8 @@ def _Device_Out(*args, **kargs):
 
 longin = _Device_In('longin', c_int32, fields.DBF_LONG, EPICS_OK)
 longout = _Device_Out('longout', c_int32, fields.DBF_LONG, EPICS_OK)
+int64in = _Device_In('int64in', c_int64, fields.DBF_INT64, EPICS_OK)
+int64out = _Device_Out('int64out', c_int64, fields.DBF_INT64, EPICS_OK)
 bi = _Device_In('bi', c_uint16, fields.DBF_CHAR, NO_CONVERT)
 bo = _Device_Out('bo', c_uint16, fields.DBF_CHAR, NO_CONVERT)
 mbbi = _Device_In('mbbi', c_uint16, fields.DBF_SHORT, NO_CONVERT)

--- a/softioc/extension.c
+++ b/softioc/extension.c
@@ -32,7 +32,7 @@ static void set_dict_item_steal(
 
 /* Alas, EPICS has changed the numerical assignments of the DBF_ enums between
  * versions, so to avoid unpleasant surprises, we compute thes values here in C
- * and pass them back to the Python layer. */
+ * and pass them back to the Python layer. Order matches dbFldTypes.h. */
 static PyObject *get_DBF_values(PyObject *self, PyObject *args)
 {
     PyObject *dict = PyDict_New();
@@ -43,6 +43,8 @@ static PyObject *get_DBF_values(PyObject *self, PyObject *args)
     ADD_ENUM(dict, DBF_USHORT);
     ADD_ENUM(dict, DBF_LONG);
     ADD_ENUM(dict, DBF_ULONG);
+    ADD_ENUM(dict, DBF_INT64);
+    ADD_ENUM(dict, DBF_UINT64);
     ADD_ENUM(dict, DBF_FLOAT);
     ADD_ENUM(dict, DBF_DOUBLE);
     ADD_ENUM(dict, DBF_ENUM);

--- a/softioc/fields.py
+++ b/softioc/fields.py
@@ -32,7 +32,7 @@ DbfCodeToCtypes = {
     DBF_USHORT: c_uint16,
     DBF_LONG: c_int32,
     DBF_INT64: c_int64,
-    DBF_UINT64: c_uint64,  # TODO: Check whether this has same issue as below note
+    DBF_UINT64: c_uint64,
     DBF_ULONG: c_int32,    # Should be uint32, but causes trouble later.
     DBF_FLOAT: c_float,
     DBF_DOUBLE: c_double,

--- a/softioc/fields.py
+++ b/softioc/fields.py
@@ -2,10 +2,9 @@
 
 from __future__ import print_function
 
-import sys
 from ctypes import *
 from .imports import get_field_offsets, get_DBF_values
-import numpy
+
 
 from epicscorelibs.ca.dbr import *
 from epicscorelibs.ca.dbr import ca_timestamp, EPICS_epoch
@@ -32,6 +31,8 @@ DbfCodeToCtypes = {
     DBF_SHORT: c_int16,
     DBF_USHORT: c_uint16,
     DBF_LONG: c_int32,
+    DBF_INT64: c_int64,
+    DBF_UINT64: c_uint64,  # TODO: Check whether this has same issue as below note
     DBF_ULONG: c_int32,    # Should be uint32, but causes trouble later.
     DBF_FLOAT: c_float,
     DBF_DOUBLE: c_double,
@@ -50,6 +51,8 @@ DbrToDbfCode = {
     DBR_ENUM: DBF_ENUM,
     DBR_CHAR: DBF_CHAR,
     DBR_LONG: DBF_LONG,
+    # DBR_INT64: DBF_INT64,  # TODO: the DBR_ definitions come from epicscorelibs.ca.dbr, but they don't define the 64 versions
+    # DBR_UINT64: DBF_UINT64,
     DBR_DOUBLE: DBF_DOUBLE
 }
 

--- a/softioc/fields.py
+++ b/softioc/fields.py
@@ -43,19 +43,6 @@ DbfCodeToCtypes = {
     DBF_NOACCESS: c_void_p,
 }
 
-# Mapping from basic DBR_ codes to DBF_ values
-DbrToDbfCode = {
-    DBR_STRING: DBF_STRING,
-    DBR_SHORT: DBF_SHORT,
-    DBR_FLOAT: DBF_FLOAT,
-    DBR_ENUM: DBF_ENUM,
-    DBR_CHAR: DBF_CHAR,
-    DBR_LONG: DBF_LONG,
-    # DBR_INT64: DBF_INT64,  # TODO: the DBR_ definitions come from epicscorelibs.ca.dbr, but they don't define the 64 versions
-    # DBR_UINT64: DBF_UINT64,
-    DBR_DOUBLE: DBF_DOUBLE
-}
-
 
 class RecordFactory(object):
     def __init__(self, record_type, fields):

--- a/softioc/pythonSoftIoc.py
+++ b/softioc/pythonSoftIoc.py
@@ -89,8 +89,9 @@ class PythonDevice(object):
     @classmethod
     def __init_class__(cls):
         for name in [
-                'ai', 'bi', 'longin',  'mbbi', 'stringin',
-                'ao', 'bo', 'longout', 'mbbo', 'stringout', 'waveform']:
+                'ai', 'bi', 'longin',  'mbbi', 'stringin', 'int64in',
+                'ao', 'bo', 'longout', 'mbbo', 'stringout', 'int64out',
+                'waveform']:
             builder = getattr(epicsdbbuilder.records, name)
             record = getattr(device, name)
             setattr(cls, name, cls.makeRecord(builder, record))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,19 @@ import sys
 from typing import Any
 import pytest
 
+from softioc import builder
 from softioc.builder import ClearRecords
+
+in_records = [
+    builder.aIn,
+    builder.boolIn,
+    builder.longIn,
+    builder.int64In,
+    builder.mbbIn,
+    builder.stringIn,
+    builder.WaveformIn,
+    builder.longStringIn,
+]
 
 requires_cothread = pytest.mark.skipif(
     sys.platform.startswith("win"), reason="Cothread doesn't work on windows"

--- a/tests/test_record_values.py
+++ b/tests/test_record_values.py
@@ -1,4 +1,3 @@
-import multiprocessing
 from typing import List
 import numpy
 import pytest
@@ -12,7 +11,8 @@ from conftest import (
     log,
     select_and_recv,
     TIMEOUT,
-    get_multiprocessing_context
+    get_multiprocessing_context,
+    in_records,
 )
 
 from softioc import asyncio_dispatcher, builder, softioc
@@ -54,6 +54,8 @@ def record_func_names(fixture_value):
         builder.WaveformOut,
         builder.longStringIn,
         builder.longStringOut,
+        builder.int64In,
+        builder.int64Out,
     ],
     ids=record_func_names,
 )
@@ -61,16 +63,6 @@ def record_func(request):
     """The list of record creation functions"""
     return request.param
 
-# A list of all In records, used to filter out various tests
-in_records = [
-    builder.aIn,
-    builder.boolIn,
-    builder.longIn,
-    builder.mbbIn,
-    builder.stringIn,
-    builder.WaveformIn,
-    builder.longStringIn,
-]
 
 def record_values_names(fixture_value):
     """Provide a nice name for the tests in the record_values fixture"""
@@ -96,6 +88,8 @@ record_values_list = [
     ("aOut_nan", builder.aOut, nan, nan, float),
     ("longIn_int", builder.longIn, 5, 5, int),
     ("longOut_int", builder.longOut, 5, 5, int),
+    ("int64In_int", builder.int64In, 65, 65, int),
+    ("int64Out_int", builder.int64Out, 65, 65, int),
     ("boolIn_int", builder.boolIn, 1, 1, int),
     ("boolOut_int", builder.boolOut, 1, 1, int),
     ("boolIn_true", builder.boolIn, True, 1, int),
@@ -737,6 +731,8 @@ default_values_list = [
     ("default_aIn", builder.aIn, None, 0.0, float),
     ("default_longOut", builder.longOut, None, 0, int),
     ("default_longIn", builder.longIn, None, 0, int),
+    ("default_int64Out", builder.int64Out, None, 0, int),
+    ("default_int64In", builder.int64In, None, 0, int),
     ("default_boolOut", builder.boolOut, None, 0, int),
     ("default_boolIn", builder.boolIn, None, 0, int),
     ("default_Action", builder.Action, None, 0, int),
@@ -761,6 +757,8 @@ class TestDefaultValue:
             (builder.aIn, 0.0, float),
             (builder.longOut, 0, int),
             (builder.longIn, 0, int),
+            (builder.int64Out, 0, int),
+            (builder.int64In, 0, int),
             (builder.boolOut, 0, int),
             (builder.boolIn, 0, int),
             (builder.Action, 0, int),

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -12,7 +12,8 @@ from conftest import (
     WAVEFORM_LENGTH,
     TIMEOUT,
     select_and_recv,
-    get_multiprocessing_context
+    get_multiprocessing_context,
+    in_records
 )
 
 from softioc import alarm, asyncio_dispatcher, builder, softioc
@@ -24,16 +25,6 @@ from softioc.device_core import LookupRecord, LookupRecordList
 
 # Test parameters
 DEVICE_NAME = "RECORD-TESTS"
-
-in_records = [
-    builder.aIn,
-    builder.boolIn,
-    builder.longIn,
-    builder.mbbIn,
-    builder.stringIn,
-    builder.WaveformIn,
-    builder.longStringIn,
-]
 
 def test_records(tmp_path):
     # Ensure we definitely unload all records that may be hanging over from
@@ -362,6 +353,7 @@ class TestValidate:
             (builder.boolOut, 1, 0),
             (builder.Action, 1, 0),
             (builder.longOut, 7, 0),
+            (builder.int64Out, 54, 0),
             (builder.stringOut, "HI", ""),
             (builder.mbbOut, 2, 0),
             (builder.WaveformOut, [10, 11, 12], []),
@@ -504,6 +496,7 @@ class TestOnUpdate:
             builder.boolOut,
             # builder.Action, This is just boolOut + always_update
             builder.longOut,
+            builder.int64Out,
             builder.stringOut,
             builder.mbbOut,
             builder.WaveformOut,
@@ -1224,6 +1217,7 @@ class TestAlarms:
     records = [
         (builder.aIn, "AI_AlarmPV"),
         (builder.boolIn, "BI_AlarmPV"),
+        (builder.int64Out, "I64I_AlarmPV"),
         (builder.longIn, "LI_AlarmPV"),
         (builder.mbbIn, "MBBI_AlarmPV"),
         (builder.stringIn, "SI_AlarmPV"),
@@ -1231,6 +1225,7 @@ class TestAlarms:
         (builder.longStringIn, "LSI_AlarmPV"),
         (builder.aOut, "AO_AlarmPV"),
         (builder.boolOut, "BO_AlarmPV"),
+        (builder.int64Out, "I64O_AlarmPV"),
         (builder.longOut, "LO_AlarmPV"),
         (builder.stringOut, "SO_AlarmPV"),
         (builder.mbbOut, "MBBO_AlarmPV"),


### PR DESCRIPTION
Add support for the [int64in](https://epics.anl.gov/base/R7-0/6-docs/int64inRecord.html) and [int64out](https://epics.anl.gov/base/R7-0/6-docs/int64outRecord.html) record types. 

There's two TODOs and some test failures that needs discussion: 
- The `DBR_*` types we use come from `epicscorelibs`, however its latest version does not define the (new) `DBR_INT64` and `DBR_UINT64` types. Is it worth trying to get a PR through that module that adds these codes before merging this?
- I don't fully understand the note next to DBF_ULONG as to why it is an int32, rather than uint32. Will I need to do the same kind of transformation for DBF_UINT64?
- There are a variety of test failures due to `caget` not being able to transport an int64, instead transporting it as a float. Should I special-case these tests to accept this, or is there a better mechanism to force what we want? I see that `caget` does NOT claim to support `datatype=DBR_INT64`.

Various reference materials:
Changelog for introduction of the records: https://github.com/epics-base/epics-base/blob/7.0/documentation/RELEASE_NOTES.md#ioc-database-support-for-64-bit-integers
EPICS header file that defines both DBR_ and DBF_ codes: https://github.com/epics-base/epics-base/blob/7.0/modules/database/src/ioc/dbStatic/dbFldTypes.h


Closes #160 Closes #118