### PR TITLE
Ensure returned numpy arrays are not writeable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Removed:
 Changed:
 
 - `AsyncioDispatcher cleanup tasks atexit <../../pull/138>`_
+- `Ensure returned numpy arrays are not writeable <../../pull/164>`_
 
 Fixed:
 

--- a/softioc/device.py
+++ b/softioc/device.py
@@ -467,7 +467,12 @@ class WaveformBase(ProcessDeviceSupportCore):
         # common class of bug, at the cost of duplicated code and data, here we
         # ensure a copy is taken of the value.
         assert len(value) <= self._nelm, 'Value too long for waveform'
-        return numpy.copy(value)
+
+        value = numpy.copy(value)
+        # As we return a reference to the numpy array, ensure it cannot be
+        # modified under our noses
+        value.flags.writeable = False
+        return value
 
     def _epics_to_value(self, value):
         if self._dtype.char == 'S':

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -340,6 +340,19 @@ def test_record_wrapper_str():
     # If we never receive R it probably means an assert failed
     select_and_recv(parent_conn, "R")
 
+def test_waveform_values_not_modifiable():
+    """Test that arrays returned from waveform records are not modifiable"""
+
+    wi = builder.WaveformIn("WI", [1, 2, 3])
+    wo = builder.WaveformOut("WO", [1, 2, 3])
+
+    with pytest.raises(ValueError):
+        wi.get()[0] = 5
+
+    with pytest.raises(ValueError):
+        wo.get()[0] = 5
+
+
 def validate_fixture_names(params):
     """Provide nice names for the out_records fixture in TestValidate class"""
     return params[0].__name__


### PR DESCRIPTION
As we return a reference to the numpy array, rather than a copy, we want to ensure that the value is not modified under our noses. 

Now when you try and modify a returned array there will be a ValueError raised.


See documentation here:
https://numpy.org/doc/stable/reference/generated/numpy.ndarray.flags.html